### PR TITLE
Derive Debug for modes

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -21,8 +21,10 @@ pub struct ModeChangeError<CommE, PinE, DEV> {
 /// Device operation modes
 pub mod mode {
     /// Magnetometer one-shot (single) mode
+    #[derive(Debug)]
     pub struct MagOneShot;
     /// Magnetometer continuous mode
+    #[derive(Debug)]
     pub struct MagContinuous;
 }
 


### PR DESCRIPTION
This allows using Debug on the full device, and thus .unwrap() on .into_mag_continuous().

Without this, errors like this show when trying to unwrap:

```
error[E0599]: the method `unwrap` exists for enum `Result<lsm303agr::Lsm303agr<I2cInterface<I2CDevice>, MagContinuous>, ModeChangeError<riot_wrappers::i2c::Error, (), lsm303agr::Lsm303agr<I2cInterface<I2CDevice>, MagOneShot>>>`, but its trait bounds were not satisfied
  --> src/lib.rs:20:51
   |
20 |     let mut sensor = sensor.into_mag_continuous().unwrap();
   |                                                   ^^^^^^ method cannot be called on `Result<lsm303agr::Lsm303agr<I2cInterface<I2CDevice>, MagContinuous>, ModeChangeError<riot_wrappers::i2c::Error, (), lsm303agr::Lsm303agr<I2cInterface<I2CDevice>, MagOneShot>>>` due to unsatisfied trait bounds
   | 
  ::: /home/chrysn/git/crates/lsm303agr-rs/src/types.rs:14:1
   |
14 | pub struct ModeChangeError<CommE, PinE, DEV> {
   | -------------------------------------------- doesn't satisfy `_: Debug`
   |
   = note: the following trait bounds were not satisfied:
           `ModeChangeError<riot_wrappers::i2c::Error, (), lsm303agr::Lsm303agr<I2cInterface<I2CDevice>, MagOneShot>>: Debug`


```