### PR TITLE
Add methods to verify device id

### DIFF
--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -1,7 +1,8 @@
 use crate::{
     interface::{I2cInterface, ReadData, SpiInterface, WriteData},
-    mode, BitFlags as BF, Config, Error, Lsm303agr, PhantomData, Register, Status,
-    UnscaledMeasurement,
+    mode,
+    register_address::{WHO_AM_I_A_VAL, WHO_AM_I_M_VAL},
+    BitFlags as BF, Config, Error, Lsm303agr, PhantomData, Register, Status, UnscaledMeasurement,
 };
 
 impl<I2C> Lsm303agr<I2cInterface<I2C>, mode::MagOneShot> {
@@ -108,9 +109,19 @@ where
         self.iface.read_accel_register(Register::WHO_AM_I_A)
     }
 
+    /// Read and verify the accelerometer device ID
+    pub fn accelerometer_is_detected(&mut self) -> Result<bool, Error<CommE, PinE>> {
+        Ok(self.accelerometer_id()? == WHO_AM_I_A_VAL)
+    }
+
     /// Get magnetometer device ID
     pub fn magnetometer_id(&mut self) -> Result<u8, Error<CommE, PinE>> {
         self.iface.read_mag_register(Register::WHO_AM_I_M)
+    }
+
+    /// Read and verify the magnetometer device ID
+    pub fn magnetometer_is_detected(&mut self) -> Result<bool, Error<CommE, PinE>> {
+        Ok(self.magnetometer_id()? == WHO_AM_I_M_VAL)
     }
 }
 

--- a/src/register_address.rs
+++ b/src/register_address.rs
@@ -12,6 +12,9 @@ impl Register {
     pub const OUTX_L_REG_M: u8 = 0x68;
 }
 
+pub const WHO_AM_I_A_VAL: u8 = 0x33;
+pub const WHO_AM_I_M_VAL: u8 = 0x40;
+
 pub struct BitFlags;
 impl BitFlags {
     pub const SPI_RW: u8 = 1 << 7;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -33,6 +33,18 @@ fn i2c_can_get_accel_id() {
 }
 
 #[test]
+fn i2c_accelerometer_is_detected() {
+    let accel_id = 0x33;
+    let mut sensor = new_i2c(&[I2cTrans::write_read(
+        ACCEL_ADDR,
+        vec![Register::WHO_AM_I_A],
+        vec![accel_id],
+    )]);
+    assert!(sensor.accelerometer_is_detected().unwrap());
+    destroy_i2c(sensor);
+}
+
+#[test]
 fn i2c_can_get_mag_id() {
     let mag_id = 0xAB;
     let mut sensor = new_i2c(&[I2cTrans::write_read(
@@ -42,6 +54,18 @@ fn i2c_can_get_mag_id() {
     )]);
     let id = sensor.magnetometer_id().unwrap();
     assert_eq!(mag_id, id);
+    destroy_i2c(sensor);
+}
+
+#[test]
+fn i2c_magnetometer_is_detected() {
+    let mag_id = 0x40;
+    let mut sensor = new_i2c(&[I2cTrans::write_read(
+        MAG_ADDR,
+        vec![Register::WHO_AM_I_M],
+        vec![mag_id],
+    )]);
+    assert!(sensor.magnetometer_is_detected().unwrap());
     destroy_i2c(sensor);
 }
 
@@ -61,6 +85,20 @@ fn spi_can_get_accel_id() {
 }
 
 #[test]
+fn spi_accelerometer_is_detected() {
+    let accel_id = 0x33;
+    let mut sensor = new_spi_accel(
+        &[SpiTrans::transfer(
+            vec![BF::SPI_RW | Register::WHO_AM_I_A, 0],
+            vec![0, accel_id],
+        )],
+        default_cs(),
+    );
+    assert!(sensor.accelerometer_is_detected().unwrap());
+    destroy_spi(sensor);
+}
+
+#[test]
 fn spi_can_get_mag_id() {
     let mag_id = 0xAB;
     let mut sensor = new_spi_mag(
@@ -72,6 +110,20 @@ fn spi_can_get_mag_id() {
     );
     let id = sensor.magnetometer_id().unwrap();
     assert_eq!(mag_id, id);
+    destroy_spi(sensor);
+}
+
+#[test]
+fn spi_magnetometer_is_detected() {
+    let mag_id = 0x40;
+    let mut sensor = new_spi_mag(
+        &[SpiTrans::transfer(
+            vec![BF::SPI_RW | Register::WHO_AM_I_M, 0],
+            vec![0, mag_id],
+        )],
+        default_cs(),
+    );
+    assert!(sensor.magnetometer_is_detected().unwrap());
     destroy_spi(sensor);
 }
 


### PR DESCRIPTION
Add methods to read and also verify the device ID. These are useful for quickly checking if the device is available on the bus.

You can see this done in the [microbit-dal here](https://github.com/lancaster-university/microbit-dal/blob/master/source/drivers/LSM303Accelerometer.cpp#L193-L201) and then used to [detect which accelerometer is connected here](https://github.com/lancaster-university/microbit-dal/blob/master/source/drivers/MicroBitAccelerometer.cpp#L91-L98).