### PR TITLE
Reset all ODR bits on power down

### DIFF
--- a/src/accel_mode_and_odr.rs
+++ b/src/accel_mode_and_odr.rs
@@ -73,7 +73,7 @@ where
                 self.enable_lp()?;
             }
             AccelMode::PowerDown => {
-                let reg1 = self.ctrl_reg1_a.bits & !(0x7 << 4);
+                let reg1 = self.ctrl_reg1_a.bits & !(0xf << 4);
                 self.iface
                     .write_accel_register(Register::CTRL_REG1_A, reg1)?;
                 self.ctrl_reg1_a = reg1.into();

--- a/tests/accel_mode_and_odr.rs
+++ b/tests/accel_mode_and_odr.rs
@@ -145,3 +145,23 @@ fn can_set_mode_low_power() {
     sensor.set_accel_mode(Mode::LowPower).unwrap();
     destroy_i2c(sensor);
 }
+
+#[test]
+fn can_power_down_after_odr3() {
+    let mut sensor = new_i2c(&[
+        I2cTrans::write(
+            ACCEL_ADDR,
+            vec![
+                Register::CTRL_REG1_A,
+                DEFAULT_CTRL_REG1_A | BF::LP_EN | 8 << 4,
+            ],
+        ),
+        I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | BF::LP_EN],
+        ),
+    ]);
+    sensor.set_accel_odr(ODR::Khz1_620LowPower).unwrap();
+    sensor.set_accel_mode(Mode::PowerDown).unwrap();
+    destroy_i2c(sensor);
+}


### PR DESCRIPTION
Powering down was only resetting ODR0 - ODR3 while it should be resetting all ODR bits.

<img width="731" alt="relevant section of datasheet" src="https://user-images.githubusercontent.com/14287/123123389-b4202b00-d43e-11eb-9af0-f69b801f86d0.png">
