### PR TITLE
Scale measurements

### DIFF
--- a/src/accel_mode_and_odr.rs
+++ b/src/accel_mode_and_odr.rs
@@ -107,10 +107,10 @@ where
     /// where g is the gravity of the earth (~9.82 m/s²).
     pub fn set_accel_scale(&mut self, scale: AccelScale) -> Result<(), Error<CommE, PinE>> {
         let fs = match scale {
-            AccelScale::Scale2g => 0b00,
-            AccelScale::Scale4g => 0b01,
-            AccelScale::Scale8g => 0b10,
-            AccelScale::Scale16g => 0b11,
+            AccelScale::G2 => 0b00,
+            AccelScale::G4 => 0b01,
+            AccelScale::G8 => 0b10,
+            AccelScale::G16 => 0b11,
         };
         let reg4 = self.ctrl_reg4_a.bits & !(0b11 << 4) | (fs << 4);
         self.iface
@@ -123,10 +123,10 @@ where
     pub fn get_accel_scale(&self) -> AccelScale {
         let fs = (self.ctrl_reg4_a.bits & (0b11 << 4)) >> 4;
         match fs {
-            0b00 => AccelScale::Scale2g,
-            0b01 => AccelScale::Scale4g,
-            0b10 => AccelScale::Scale8g,
-            0b11 => AccelScale::Scale16g,
+            0b00 => AccelScale::G2,
+            0b01 => AccelScale::G4,
+            0b10 => AccelScale::G8,
+            0b11 => AccelScale::G16,
             _ => unreachable!("bit shift above means we cannot be here"),
         }
     }

--- a/src/accel_mode_and_odr.rs
+++ b/src/accel_mode_and_odr.rs
@@ -103,7 +103,7 @@ where
     /// Set accelerometer scaling factor
     ///
     /// This changes the scale at which the acceleration is read.
-    /// Accel2g for example can return values between -2g and +2g
+    /// `AccelScale::G2` for example can return values between -2g and +2g
     /// where g is the gravity of the earth (~9.82 m/s²).
     pub fn set_accel_scale(&mut self, scale: AccelScale) -> Result<(), Error<CommE, PinE>> {
         let fs = match scale {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,33 +5,21 @@
 //! [`embedded-hal`]: https://github.com/rust-embedded/embedded-hal
 //!
 //! This driver allows you to:
-//! - Connect through I2C or SPI. See: [`new_with_i2c()`].
-//! - Initialize the device. See: [`init()`].
+//! - Connect through I2C or SPI. See: [`new_with_i2c()`](Lsm303agr::new_with_i2c).
+//! - Initialize the device. See: [`init()`](Lsm303agr::init).
 //! - Accelerometer:
-//!     - Read accelerometer data. See: [`accel_data()`].
-//!     - Get accelerometer status. See: [`accel_status()`].
-//!     - Set accelerometer output data rate. See: [`set_accel_odr()`].
-//!     - Set accelerometer mode. See: [`set_accel_mode()`].
-//!     - Get accelerometer ID. See: [`accelerometer_id()`].
+//!     - Read accelerometer data. See: [`accel_data()`](Lsm303agr::accel_data).
+//!     - Get accelerometer status. See: [`accel_status()`](Lsm303agr::accel_status).
+//!     - Set accelerometer output data rate. See: [`set_accel_odr()`](Lsm303agr::set_accel_odr).
+//!     - Set accelerometer mode. See: [`set_accel_mode()`](Lsm303agr::set_accel_mode).
+//!     - Set accelerometer scale. See: [`set_accel_scale()`](Lsm303agr::set_accel_scale).
+//!     - Get accelerometer ID. See: [`accelerometer_id()`](Lsm303agr::accelerometer_id).
 //! - Magnetometer:
-//!     - Get the magnetometer status. See: [`mag_status()`].
-//!     - Change into continuous/one-shot mode. See: [`into_mag_continuous()`].
-//!     - Read magnetometer data. See: [`mag_data()`].
-//!     - Set magnetometer output data rate. See: [`set_mag_odr()`].
-//!     - Get magnetometer ID. See: [`magnetometer_id()`].
-//!
-//! [`new_with_i2c()`]: struct.Lsm303agr.html#method.new_with_i2c
-//! [`init()`]: struct.Lsm303agr.html#method.init
-//! [`accel_status()`]: struct.Lsm303agr.html#method.accel_status
-//! [`accel_data()`]: struct.Lsm303agr.html#method.accel_data
-//! [`set_accel_odr()`]: struct.Lsm303agr.html#method.set_accel_odr
-//! [`set_accel_mode()`]: struct.Lsm303agr.html#method.set_accel_mode
-//! [`mag_status()`]: struct.Lsm303agr.html#method.mag_status
-//! [`into_mag_continuous()`]: struct.Lsm303agr.html#method.into_mag_continuous
-//! [`set_mag_odr()`]: struct.Lsm303agr.html#method.set_mag_odr
-//! [`mag_data()`]: struct.Lsm303agr.html#method.mag_data
-//! [`accelerometer_id()`]: struct.Lsm303agr.html#method.accelerometer_id
-//! [`magnetometer_id()`]: struct.Lsm303agr.html#method.magnetometer_id
+//!     - Get the magnetometer status. See: [`mag_status()`](Lsm303agr::mag_status).
+//!     - Change into continuous/one-shot mode. See: [`into_mag_continuous()`](Lsm303agr::into_mag_continuous).
+//!     - Read magnetometer data. See: [`mag_data()`](Lsm303agr::mag_data).
+//!     - Set magnetometer output data rate. See: [`set_mag_odr()`](Lsm303agr::set_mag_odr).
+//!     - Get magnetometer ID. See: [`magnetometer_id()`](Lsm303agr::magnetometer_id).
 //!
 //! <!-- TODO
 //! [Introductory blog post](TODO)
@@ -62,7 +50,7 @@
 //! stabilization) applications in conjunction with camera modules, or in
 //! advanced gaming use cases.
 //!
-//! Documents: [Datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-lsm303agr-ds000.pdf) - [Application note](https://www.st.com/resource/en/application_note/dm00265383-ultracompact-highperformance-ecompass-module-based-on-the-lsm303agr-stmicroelectronics.pdf)
+//! Documents: [Datasheet](https://www.st.com/resource/en/datasheet/lsm303agr.pdf) - [Application note](https://www.st.com/resource/en/application_note/dm00265383-ultracompact-highperformance-ecompass-module-based-on-the-lsm303agr-stmicroelectronics.pdf)
 //!
 //!
 //! ## Usage examples (see also examples folder)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,8 @@ mod mag_mode_change;
 mod magnetometer;
 mod types;
 pub use crate::types::{
-    mode, AccelMode, AccelOutputDataRate, Error, MagOutputDataRate, Measurement, ModeChangeError,
-    Status,
+    mode, AccelMode, AccelOutputDataRate, AccelScale, Error, MagOutputDataRate, Measurement,
+    ModeChangeError, Status,
 };
 mod register_address;
 use crate::register_address::{BitFlags, Register};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ mod magnetometer;
 mod types;
 pub use crate::types::{
     mode, AccelMode, AccelOutputDataRate, AccelScale, Error, MagOutputDataRate, Measurement,
-    ModeChangeError, Status,
+    ModeChangeError, Status, UnscaledMeasurement,
 };
 mod register_address;
 use crate::register_address::{BitFlags, Register};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,8 @@ mod mag_mode_change;
 mod magnetometer;
 mod types;
 pub use crate::types::{
-    mode, AccelMode, AccelOutputDataRate, Error, MagOutputDataRate, ModeChangeError, Status,
-    UnscaledMeasurement,
+    mode, AccelMode, AccelOutputDataRate, Error, MagOutputDataRate, Measurement, ModeChangeError,
+    Status,
 };
 mod register_address;
 use crate::register_address::{BitFlags, Register};

--- a/src/types.rs
+++ b/src/types.rs
@@ -77,6 +77,19 @@ pub enum AccelMode {
     HighResolution,
 }
 
+/// Accelerometer scaling factor
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AccelScale {
+    /// Plus or minus 2g
+    Scale2g,
+    /// Plus or minus 4g
+    Scale4g,
+    /// Plus or minus 8g
+    Scale8g,
+    /// Plus or minus 16g
+    Scale16g,
+}
+
 /// Magnetometer output data rate
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MagOutputDataRate {

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,7 +39,7 @@ pub struct Measurement {
     pub z: i32,
 }
 
-/// Unscaled easurement
+/// Unscaled measurement
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct UnscaledMeasurement {
     /// X-axis data.

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,15 +28,15 @@ pub mod mode {
     pub struct MagContinuous;
 }
 
-/// Unscaled measurement
+/// Measurement
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct UnscaledMeasurement {
+pub struct Measurement {
     /// X-axis data.
-    pub x: i16,
+    pub x: i32,
     /// Y-axis data.
-    pub y: i16,
+    pub y: i32,
     /// Z-axis data.
-    pub z: i16,
+    pub z: i32,
 }
 
 /// Accelerometer output data rate

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,6 +39,17 @@ pub struct Measurement {
     pub z: i32,
 }
 
+/// Unscaled easurement
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct UnscaledMeasurement {
+    /// X-axis data.
+    pub x: i16,
+    /// Y-axis data.
+    pub y: i16,
+    /// Z-axis data.
+    pub z: i16,
+}
+
 /// Accelerometer output data rate
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AccelOutputDataRate {
@@ -81,13 +92,13 @@ pub enum AccelMode {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AccelScale {
     /// Plus or minus 2g
-    Scale2g,
+    G2,
     /// Plus or minus 4g
-    Scale4g,
+    G4,
     /// Plus or minus 8g
-    Scale8g,
+    G8,
     /// Plus or minus 16g
-    Scale16g,
+    G16,
 }
 
 /// Magnetometer output data rate

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,6 +31,9 @@ impl Register {
     pub const OUTX_L_REG_M: u8 = 0x68;
 }
 
+#[allow(unused)]
+pub const HZ50: u8 = 4 << 4;
+
 pub struct BitFlags;
 #[allow(unused)]
 impl BitFlags {
@@ -56,7 +59,19 @@ impl BitFlags {
 
 #[allow(unused)]
 pub fn default_cs() -> PinMock {
-    PinMock::new(&[PinTrans::set(PinState::Low), PinTrans::set(PinState::High)])
+    default_cs_n(1)
+}
+
+#[allow(unused)]
+pub fn default_cs_n(n: usize) -> PinMock {
+    PinMock::new(
+        &[PinTrans::set(PinState::Low), PinTrans::set(PinState::High)]
+            .iter()
+            .cycle()
+            .cloned()
+            .take(n * 2)
+            .collect::<Vec<_>>(),
+    )
 }
 
 #[allow(unused)]

--- a/tests/magnetometer.rs
+++ b/tests/magnetometer.rs
@@ -8,7 +8,7 @@ use embedded_hal_mock::{
     pin::{Mock as PinMock, State as PinState, Transaction as PinTrans},
     spi::Transaction as SpiTrans,
 };
-use lsm303agr::{MagOutputDataRate as ODR, UnscaledMeasurement};
+use lsm303agr::{MagOutputDataRate as ODR, Measurement};
 use nb;
 
 macro_rules! set_mag_odr {
@@ -47,10 +47,10 @@ fn can_take_one_shot_measurement() {
     let data = nb::block!(sensor.mag_data()).unwrap();
     assert_eq!(
         data,
-        UnscaledMeasurement {
-            x: 0x2010,
-            y: 0x4030,
-            z: 0x6050
+        Measurement {
+            x: 1231200,  // 0x2010 * 150
+            y: 2464800,  // 0x4030 * 150
+            z: 3698400,  // 0x6050 * 150
         }
     );
     destroy_i2c(sensor);
@@ -70,10 +70,10 @@ fn can_take_continuous_measurement() {
     let data = sensor.mag_data().unwrap();
     assert_eq!(
         data,
-        UnscaledMeasurement {
-            x: 0x2010,
-            y: 0x4030,
-            z: 0x6050
+        Measurement {
+            x: 1231200,  // 0x2010 * 150
+            y: 2464800,  // 0x4030 * 150
+            z: 3698400,  // 0x6050 * 150
         }
     );
     destroy_i2c(sensor);
@@ -108,10 +108,10 @@ fn can_take_continuous_measurement_spi() {
     let data = sensor.mag_data().unwrap();
     assert_eq!(
         data,
-        UnscaledMeasurement {
-            x: 0x2010,
-            y: 0x4030,
-            z: 0x6050
+        Measurement {
+            x: 1231200,  // 0x2010 * 150
+            y: 2464800,  // 0x4030 * 150
+            z: 3698400,  // 0x6050 * 150
         }
     );
     destroy_spi(sensor);

--- a/tests/magnetometer.rs
+++ b/tests/magnetometer.rs
@@ -48,9 +48,9 @@ fn can_take_one_shot_measurement() {
     assert_eq!(
         data,
         Measurement {
-            x: 1231200,  // 0x2010 * 150
-            y: 2464800,  // 0x4030 * 150
-            z: 3698400,  // 0x6050 * 150
+            x: 1231200, // 0x2010 * 150
+            y: 2464800, // 0x4030 * 150
+            z: 3698400, // 0x6050 * 150
         }
     );
     destroy_i2c(sensor);
@@ -71,9 +71,9 @@ fn can_take_continuous_measurement() {
     assert_eq!(
         data,
         Measurement {
-            x: 1231200,  // 0x2010 * 150
-            y: 2464800,  // 0x4030 * 150
-            z: 3698400,  // 0x6050 * 150
+            x: 1231200, // 0x2010 * 150
+            y: 2464800, // 0x4030 * 150
+            z: 3698400, // 0x6050 * 150
         }
     );
     destroy_i2c(sensor);
@@ -109,9 +109,9 @@ fn can_take_continuous_measurement_spi() {
     assert_eq!(
         data,
         Measurement {
-            x: 1231200,  // 0x2010 * 150
-            y: 2464800,  // 0x4030 * 150
-            z: 3698400,  // 0x6050 * 150
+            x: 1231200, // 0x2010 * 150
+            y: 2464800, // 0x4030 * 150
+            z: 3698400, // 0x6050 * 150
         }
     );
     destroy_spi(sensor);

--- a/tests/read_accel.rs
+++ b/tests/read_accel.rs
@@ -1,23 +1,132 @@
 mod common;
 use crate::common::{
-    default_cs, destroy_i2c, destroy_spi, new_i2c, new_spi_accel, BitFlags as BF, Register,
-    ACCEL_ADDR, DEFAULT_CTRL_REG1_A,
+    default_cs_n, destroy_i2c, destroy_spi, new_i2c, new_spi_accel, BitFlags as BF, Register,
+    ACCEL_ADDR, DEFAULT_CTRL_REG1_A, HZ50,
 };
 use embedded_hal_mock::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
-use lsm303agr::{AccelMode, Measurement};
+use lsm303agr::{AccelMode, AccelOutputDataRate, AccelScale, Measurement};
+
+fn i2c_mode_txns(mode: &AccelMode) -> Vec<I2cTrans> {
+    match mode {
+        AccelMode::Normal => vec![],
+        AccelMode::LowPower => vec![
+            I2cTrans::write(ACCEL_ADDR, vec![Register::CTRL_REG4_A, 0]),
+            I2cTrans::write(
+                ACCEL_ADDR,
+                vec![
+                    Register::CTRL_REG1_A,
+                    DEFAULT_CTRL_REG1_A | BF::LP_EN | HZ50,
+                ],
+            ),
+        ],
+        AccelMode::HighResolution => vec![
+            I2cTrans::write(
+                ACCEL_ADDR,
+                vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50],
+            ),
+            I2cTrans::write(ACCEL_ADDR, vec![Register::CTRL_REG4_A, BF::HR]),
+        ],
+        AccelMode::PowerDown => panic!("cannot read i2c in power down mode"),
+    }
+}
+
+fn i2c_scale_txns(mode: &AccelMode, scale: &AccelScale) -> Vec<I2cTrans> {
+    let base_reg = match mode {
+        AccelMode::HighResolution => BF::HR,
+        _ => 0,
+    };
+    match scale {
+        AccelScale::Scale2g => vec![],
+        AccelScale::Scale4g => vec![I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG4_A, base_reg | (0b01 << 4)],
+        )],
+        AccelScale::Scale8g => vec![I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG4_A, base_reg | (0b10 << 4)],
+        )],
+        AccelScale::Scale16g => vec![I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG4_A, base_reg | (0b11 << 4)],
+        )],
+    }
+}
+
+macro_rules! can_get_i2c {
+    ( $name:ident, $mode:ident, $scale:ident, $expected:expr ) => {
+        #[test]
+        fn $name() {
+            let expected = $expected;
+            let mode = AccelMode::$mode;
+            let scale = AccelScale::$scale;
+            let mut txns: Vec<I2cTrans> = vec![I2cTrans::write(
+                ACCEL_ADDR,
+                vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50],
+            )];
+            txns.append(&mut i2c_mode_txns(&mode));
+            txns.append(&mut i2c_scale_txns(&mode, &scale));
+            txns.push(I2cTrans::write_read(
+                ACCEL_ADDR,
+                vec![Register::OUT_X_L_A | 0x80],
+                vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
+            ));
+            let mut sensor = new_i2c(&txns);
+            sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
+
+            if let AccelMode::LowPower | AccelMode::HighResolution = mode {
+                sensor.set_accel_mode(mode).unwrap();
+            }
+            if let AccelScale::Scale2g = scale {
+            } else {
+                sensor.set_accel_scale(scale).unwrap();
+            }
+
+            let actual = sensor.accel_data().unwrap();
+
+            assert_eq!(actual, expected);
+
+            destroy_i2c(sensor);
+        }
+    };
+}
+
+#[rustfmt::skip]
+mod can_get_i2c {
+    use super::*;
+
+    can_get_i2c!(low_power_2g,        LowPower,       Scale2g,  Measurement { x: 512, y: 1024, z: 1536 });
+    can_get_i2c!(high_resolution_2g,  HighResolution, Scale2g,  Measurement { x: 513, y: 1027, z: 1541 });
+    can_get_i2c!(normal_2g,           Normal,         Scale2g,  Measurement { x: 512, y: 1024, z: 1540 });
+    can_get_i2c!(low_power_4g,        LowPower,       Scale4g,  Measurement { x: 512 * 2, y: 1024 * 2, z: 1536 * 2});
+    can_get_i2c!(high_resolution_4g,  HighResolution, Scale4g,  Measurement { x: 513 * 2, y: 1027 * 2, z: 1541 * 2});
+    can_get_i2c!(normal_4g,           Normal,         Scale4g,  Measurement { x: 512 * 2, y: 1024 * 2, z: 1540 * 2});
+    can_get_i2c!(low_power_8g,        LowPower,       Scale8g,  Measurement { x: 512 * 4, y: 1024 * 4, z: 1536 * 4});
+    can_get_i2c!(high_resolution_8g,  HighResolution, Scale8g,  Measurement { x: 513 * 4, y: 1027 * 4, z: 1541 * 4});
+    can_get_i2c!(normal_8g,           Normal,         Scale8g,  Measurement { x: 512 * 4, y: 1024 * 4, z: 1540 * 4});
+    can_get_i2c!(low_power_16g,       LowPower,       Scale16g, Measurement { x: 512 * 8, y: 1024 * 8, z: 1536 * 8});
+    can_get_i2c!(high_resolution_16g, HighResolution, Scale16g, Measurement { x: 513 * 8, y: 1027 * 8, z: 1541 * 8});
+    can_get_i2c!(normal_16g,          Normal,         Scale16g, Measurement { x: 512 * 8, y: 1024 * 8, z: 1540 * 8});
+}
 
 #[test]
 fn can_get_10_bit_data() {
-    let mut sensor = new_i2c(&[I2cTrans::write_read(
-        ACCEL_ADDR,
-        vec![Register::OUT_X_L_A | 0x80],
-        vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
-    )]);
+    let mut sensor = new_i2c(&[
+        I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50],
+        ),
+        I2cTrans::write_read(
+            ACCEL_ADDR,
+            vec![Register::OUT_X_L_A | 0x80],
+            vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
+        ),
+    ]);
+    sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
         Measurement {
-            x: 512, // ~= 0x2010 / (1 << 4)
+            x: 512,  // ~= 0x2010 / (1 << 4)
             y: 1024, // ~= 0x4030 / (1 << 4)
             z: 1540, // ~= 0x6050 / (1 << 4)
         }
@@ -28,25 +137,29 @@ fn can_get_10_bit_data() {
 #[test]
 fn can_get_10_bit_data_spi() {
     let mut sensor = new_spi_accel(
-        &[SpiTrans::transfer(
-            vec![
-                Register::OUT_X_L_A | BF::SPI_RW | BF::SPI_MS,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-            ],
-            vec![0, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
-        )],
-        default_cs(),
+        &[
+            SpiTrans::write(vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50]),
+            SpiTrans::transfer(
+                vec![
+                    Register::OUT_X_L_A | BF::SPI_RW | BF::SPI_MS,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                vec![0, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
+            ),
+        ],
+        default_cs_n(2),
     );
+    sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
         Measurement {
-            x: 512, // ~= 0x2010 / (1 << 4),
+            x: 512,  // ~= 0x2010 / (1 << 4),
             y: 1024, // ~= 0x4030 / (1 << 4),
             z: 1540, // ~= 0x6050 / (1 << 4),
         }
@@ -57,7 +170,14 @@ fn can_get_10_bit_data_spi() {
 #[test]
 fn can_get_12_bit_data() {
     let mut sensor = new_i2c(&[
-        I2cTrans::write(ACCEL_ADDR, vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A]),
+        I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50],
+        ),
+        I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50],
+        ),
         I2cTrans::write(ACCEL_ADDR, vec![Register::CTRL_REG4_A, BF::HR]),
         I2cTrans::write_read(
             ACCEL_ADDR,
@@ -65,12 +185,13 @@ fn can_get_12_bit_data() {
             vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
         ),
     ]);
+    sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     sensor.set_accel_mode(AccelMode::HighResolution).unwrap();
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
         Measurement {
-            x: 513, // == 0x2010 / (1 << 4),
+            x: 513,  // == 0x2010 / (1 << 4),
             y: 1027, // == 0x4030 / (1 << 4),
             z: 1541, // == 0x6050 / (1 << 4),
         }
@@ -81,10 +202,17 @@ fn can_get_12_bit_data() {
 #[test]
 fn can_get_8_bit_data() {
     let mut sensor = new_i2c(&[
+        I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50],
+        ),
         I2cTrans::write(ACCEL_ADDR, vec![Register::CTRL_REG4_A, 0]),
         I2cTrans::write(
             ACCEL_ADDR,
-            vec![Register::CTRL_REG1_A, BF::LP_EN | DEFAULT_CTRL_REG1_A],
+            vec![
+                Register::CTRL_REG1_A,
+                BF::LP_EN | DEFAULT_CTRL_REG1_A | HZ50,
+            ],
         ),
         I2cTrans::write_read(
             ACCEL_ADDR,
@@ -92,12 +220,13 @@ fn can_get_8_bit_data() {
             vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
         ),
     ]);
+    sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     sensor.set_accel_mode(AccelMode::LowPower).unwrap();
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
         Measurement {
-            x: 512, // ~= 0x2010 / (1 << 4),
+            x: 512,  // ~= 0x2010 / (1 << 4),
             y: 1024, // ~= 0x4030 / (1 << 4),
             z: 1536, // ~= 0x6050 / (1 << 4),
         }

--- a/tests/read_accel.rs
+++ b/tests/read_accel.rs
@@ -4,7 +4,7 @@ use crate::common::{
     ACCEL_ADDR, DEFAULT_CTRL_REG1_A,
 };
 use embedded_hal_mock::{i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans};
-use lsm303agr::{AccelMode, UnscaledMeasurement};
+use lsm303agr::{AccelMode, Measurement};
 
 #[test]
 fn can_get_10_bit_data() {
@@ -16,10 +16,10 @@ fn can_get_10_bit_data() {
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
-        UnscaledMeasurement {
-            x: 0x2010 >> 6,
-            y: 0x4030 >> 6,
-            z: 0x6050 >> 6
+        Measurement {
+            x: 512, // ~= 0x2010 / (1 << 4)
+            y: 1024, // ~= 0x4030 / (1 << 4)
+            z: 1540, // ~= 0x6050 / (1 << 4)
         }
     );
     destroy_i2c(sensor);
@@ -45,10 +45,10 @@ fn can_get_10_bit_data_spi() {
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
-        UnscaledMeasurement {
-            x: 0x2010 >> 6,
-            y: 0x4030 >> 6,
-            z: 0x6050 >> 6
+        Measurement {
+            x: 512, // ~= 0x2010 / (1 << 4),
+            y: 1024, // ~= 0x4030 / (1 << 4),
+            z: 1540, // ~= 0x6050 / (1 << 4),
         }
     );
     destroy_spi(sensor);
@@ -69,10 +69,10 @@ fn can_get_12_bit_data() {
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
-        UnscaledMeasurement {
-            x: 0x2010 >> 4,
-            y: 0x4030 >> 4,
-            z: 0x6050 >> 4
+        Measurement {
+            x: 513, // == 0x2010 / (1 << 4),
+            y: 1027, // == 0x4030 / (1 << 4),
+            z: 1541, // == 0x6050 / (1 << 4),
         }
     );
     destroy_i2c(sensor);
@@ -96,10 +96,10 @@ fn can_get_8_bit_data() {
     let data = sensor.accel_data().unwrap();
     assert_eq!(
         data,
-        UnscaledMeasurement {
-            x: 0x20,
-            y: 0x40,
-            z: 0x60
+        Measurement {
+            x: 512, // ~= 0x2010 / (1 << 4),
+            y: 1024, // ~= 0x4030 / (1 << 4),
+            z: 1536, // ~= 0x6050 / (1 << 4),
         }
     );
     destroy_i2c(sensor);


### PR DESCRIPTION
Depends on #4 

This change scales the accelerometer and magnetometer outputs. For the accelerometer this includes being able to set the scaling factor. I have renamed `UnscaledMeasurement` to `Measurement` to make it clear that these are now scaled.

## Scaling the accelerometer
Scaling the accelerometer data to milli-g is fairly well described in the datasheet. The only area of confusion is around the 16g scaling factor. The STMicroelectronics driver has [this very confusing line](https://github.com/STMicroelectronics/stm32-lsm303agr/blob/main/lsm303agr.h#L217) which is also seen in [others](https://github.com/SodaqMoja/Sodaq_LSM303AGR/blob/master/src/Sodaq_LSM303AGR.cpp#L49). I have chosen to go with the datasheet but I am not 100% sure that is correct.

## Scaling the magnetometer
Scaling the magnetometer is a little more obscure. I have taken the 150 value from the [here in the microbit-dal](https://github.com/lancaster-university/microbit-dal/blob/master/inc/drivers/LSM303Magnetometer.h#L38) but there is very little context as to where that number comes from. The [commit that introduced it](https://github.com/lancaster-university/microbit-dal/commit/f6bee0940eaf8c83529d51d6c6c2f45cfc90c266)
does not shed any more light on the matter (although it does imply that the value has been determined
empirically). I have seen similar scaling factors used in other LSM303 drivers but have not been able to find an explanation or any reference in the datasheet.