### PR TITLE
doc: The magnetometer values are in nT not mG

### DIFF
--- a/src/magnetometer.rs
+++ b/src/magnetometer.rs
@@ -29,7 +29,7 @@ where
 {
     /// Magnetometer data
     ///
-    /// Returned in mg (milli-gauss).
+    /// Returned in nT (nanotesla)
     ///
     /// If you need the raw unscaled measurement see [`Lsm303agr::mag_data_unscaled`].
     pub fn mag_data(&mut self) -> Result<Measurement, Error<CommE, PinE>> {


### PR DESCRIPTION
commit be8451e723c0021e53d7eb7160ed534bd1abe1a1 introduced the scaling
factor of 150 from the microbit codal by lancaster university. This
factor is however explicitly mentioned to be a conversion factor to SI
units here:
https://github.com/lancaster-university/microbit-dal/blob/master/inc/drivers/LSM303Magnetometer.h#L36

With Tesla being the SI unit for magnetic field strength and the
documentatoin of the dal also declaring the output values as being
nanoteslas it is likely that this means this converts the magnetometer
raw data to nanoteslas (This is also the only way the values im
measuring with my lsm303agr are explainable).