### PR TITLE
Reduce size of status structs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, 1.31.0]
+        rust: [stable, 1.46.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Support temperature sensor.
-- Support magnetometer offset cancellation
+- Support magnetometer offset cancellation.
+- Reduce size of status structs.
 
-...
 ## [0.2.2] - 2021-09-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 [dependencies]
 embedded-hal = "0.2.5"
 nb = "1"
+bitflags = "1.3"
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ fn main() {
     sensor.init().unwrap();
     sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     loop {
-        if sensor.accel_status().unwrap().xyz_new_data {
+        if sensor.accel_status().unwrap().xyz_new_data() {
             let data = sensor.accel_data().unwrap();
             println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
         }

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -7,7 +7,7 @@ fn main() {
     sensor.init().unwrap();
     sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     loop {
-        if sensor.accel_status().unwrap().xyz_new_data {
+        if sensor.accel_status().unwrap().xyz_new_data() {
             let data = sensor.accel_data().unwrap();
             println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
         }

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -86,7 +86,7 @@ where
     pub fn accel_status(&mut self) -> Result<Status, Error<CommE, PinE>> {
         self.iface
             .read_accel_register(Register::STATUS_REG_A)
-            .map(convert_status)
+            .map(Status::new)
     }
 
     /// Accelerometer data
@@ -155,7 +155,7 @@ where
     pub fn mag_status(&mut self) -> Result<Status, Error<CommE, PinE>> {
         self.iface
             .read_mag_register(Register::STATUS_REG_M)
-            .map(convert_status)
+            .map(Status::new)
     }
 
     /// Get accelerometer device ID
@@ -198,26 +198,6 @@ where
     pub fn temperature_status(&mut self) -> Result<TemperatureStatus, Error<CommE, PinE>> {
         self.iface
             .read_accel_register(Register::STATUS_REG_AUX_A)
-            .map(convert_temperature_status)
-    }
-}
-
-fn convert_status(st: u8) -> Status {
-    Status {
-        xyz_overrun: (st & BF::XYZOR) != 0,
-        z_overrun: (st & BF::ZOR) != 0,
-        y_overrun: (st & BF::YOR) != 0,
-        x_overrun: (st & BF::XOR) != 0,
-        xyz_new_data: (st & BF::XYZDR) != 0,
-        z_new_data: (st & BF::ZDR) != 0,
-        y_new_data: (st & BF::YDR) != 0,
-        x_new_data: (st & BF::XDR) != 0,
-    }
-}
-
-fn convert_temperature_status(st: u8) -> TemperatureStatus {
-    TemperatureStatus {
-        overrun: (st & BF::TOR) != 0,
-        new_data: (st & BF::TDA) != 0,
+            .map(TemperatureStatus::new)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! sensor.set_accel_odr(AccelOutputDataRate::Hz10).unwrap();
 //!
 //! loop {
-//!     if sensor.accel_status().unwrap().xyz_new_data {
+//!     if sensor.accel_status().unwrap().xyz_new_data() {
 //!         let data = sensor.accel_data().unwrap();
 //!         println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
 //!     }
@@ -103,7 +103,7 @@
 //! sensor.set_accel_odr(AccelOutputDataRate::Hz10).unwrap();
 //!
 //! loop {
-//!     if sensor.accel_status().unwrap().xyz_new_data {
+//!     if sensor.accel_status().unwrap().xyz_new_data() {
 //!         let data = sensor.accel_data().unwrap();
 //!         println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
 //!     }

--- a/src/magnetometer.rs
+++ b/src/magnetometer.rs
@@ -101,7 +101,7 @@ where
     /// Unscaled magnetometer data
     pub fn mag_data_unscaled(&mut self) -> nb::Result<UnscaledMeasurement, Error<CommE, PinE>> {
         let status = self.mag_status()?;
-        if status.xyz_new_data {
+        if status.xyz_new_data() {
             let data = self
                 .iface
                 .read_mag_3_double_registers(Register::OUTX_L_REG_M)?;

--- a/src/register_address.rs
+++ b/src/register_address.rs
@@ -34,18 +34,6 @@ impl BitFlags {
     pub const MAG_OFF_CANC: u8 = 1 << 1;
     pub const MAG_OFF_CANC_ONE_SHOT: u8 = 1 << 4;
 
-    pub const XDR: u8 = 1;
-    pub const YDR: u8 = 1 << 1;
-    pub const ZDR: u8 = 1 << 2;
-    pub const XYZDR: u8 = 1 << 3;
-    pub const XOR: u8 = 1 << 4;
-    pub const YOR: u8 = 1 << 5;
-    pub const ZOR: u8 = 1 << 6;
-    pub const XYZOR: u8 = 1 << 7;
-
-    pub const TDA: u8 = 1 << 2;
-    pub const TOR: u8 = 1 << 6;
-
     pub const TEMP_EN0: u8 = 1 << 6;
     pub const TEMP_EN1: u8 = 1 << 7;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use bitflags::bitflags;
+
 /// All possible errors in this crate
 #[derive(Debug)]
 pub enum Error<CommE, PinE> {
@@ -114,32 +116,112 @@ pub enum MagOutputDataRate {
     Hz100,
 }
 
+bitflags! {
+    #[derive(Default)]
+    struct StatusFlags: u8 {
+        const XDA   = 1 << 0;
+        const YDA   = 1 << 1;
+        const ZDA   = 1 << 2;
+        const ZYXDA = 1 << 3;
+        const XOR   = 1 << 4;
+        const YOR   = 1 << 5;
+        const ZOR   = 1 << 6;
+        const ZYXOR = 1 << 7;
+    }
+}
+
 /// Data status
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Status {
-    /// X,Y,Z-axis data overrun
-    pub xyz_overrun: bool,
-    /// X-axis data overrun
-    pub x_overrun: bool,
-    /// Y-axis data overrun
-    pub y_overrun: bool,
-    /// Z-axis data overrun
-    pub z_overrun: bool,
-    /// X,Y,Z-axis new data ready
-    pub xyz_new_data: bool,
-    /// X-axis data new data ready
-    pub x_new_data: bool,
-    /// Y-axis data new data ready
-    pub y_new_data: bool,
-    /// Z-axis data new data ready
-    pub z_new_data: bool,
+    flags: StatusFlags,
+}
+
+impl Status {
+    pub(crate) const fn new(flags: u8) -> Self {
+        Self {
+            flags: StatusFlags::from_bits_truncate(flags),
+        }
+    }
+
+    /// X-axis new data available.
+    #[inline]
+    pub const fn x_new_data(&self) -> bool {
+        self.flags.contains(StatusFlags::XDA)
+    }
+
+    /// Y-axis new data available.
+    #[inline]
+    pub const fn y_new_data(&self) -> bool {
+        self.flags.contains(StatusFlags::YDA)
+    }
+
+    /// Z-axis new data available.
+    #[inline]
+    pub const fn z_new_data(&self) -> bool {
+        self.flags.contains(StatusFlags::ZDA)
+    }
+
+    /// X-, Y- and Z-axis new data available.
+    #[inline]
+    pub const fn xyz_new_data(&self) -> bool {
+        self.flags.contains(StatusFlags::ZYXDA)
+    }
+
+    /// X-axis data overrun.
+    #[inline]
+    pub const fn x_overrun(&self) -> bool {
+        self.flags.contains(StatusFlags::XOR)
+    }
+
+    /// Y-axis data overrun.
+    #[inline]
+    pub const fn y_overrun(&self) -> bool {
+        self.flags.contains(StatusFlags::YOR)
+    }
+
+    /// Z-axis data overrun.
+    #[inline]
+    pub const fn z_overrun(&self) -> bool {
+        self.flags.contains(StatusFlags::ZOR)
+    }
+
+    /// X-, Y- and Z-axis data overrun.
+    #[inline]
+    pub const fn xyz_overrun(&self) -> bool {
+        self.flags.contains(StatusFlags::ZYXOR)
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    struct TemperatureStatusFlags: u8 {
+        const TDA = 1 << 2;
+        const TOR = 1 << 6;
+    }
 }
 
 /// Temperature sensor status
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TemperatureStatus {
-    /// Data overrun
-    pub overrun: bool,
-    /// New data ready
-    pub new_data: bool,
+    flags: TemperatureStatusFlags,
+}
+
+impl TemperatureStatus {
+    pub(crate) const fn new(flags: u8) -> Self {
+        Self {
+            flags: TemperatureStatusFlags::from_bits_truncate(flags),
+        }
+    }
+
+    /// Temperature data overrun.
+    #[inline]
+    pub const fn overrun(&self) -> bool {
+        self.flags.contains(TemperatureStatusFlags::TOR)
+    }
+
+    /// Temperature new data available.
+    #[inline]
+    pub const fn new_data(&self) -> bool {
+        self.flags.contains(TemperatureStatusFlags::TDA)
+    }
 }

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -1,25 +1,22 @@
-use lsm303agr::Status;
 mod common;
 use crate::common::{destroy_i2c, new_i2c, BitFlags as BF, Register, ACCEL_ADDR, MAG_ADDR};
 use embedded_hal_mock::i2c::Transaction as I2cTrans;
 
 macro_rules! status_eq {
     ($st:expr, $xyz_overrun:expr, $x_overrun:expr, $y_overrun:expr, $z_overrun:expr,
-    $xyz_new_data:expr, $x_new_data:expr, $y_new_data:expr, $z_new_data:expr) => {
-        assert_eq!(
-            Status {
-                xyz_overrun: $xyz_overrun,
-                x_overrun: $x_overrun,
-                y_overrun: $y_overrun,
-                z_overrun: $z_overrun,
-                xyz_new_data: $xyz_new_data,
-                x_new_data: $x_new_data,
-                y_new_data: $y_new_data,
-                z_new_data: $z_new_data
-            },
-            $st
-        );
-    };
+    $xyz_new_data:expr, $x_new_data:expr, $y_new_data:expr, $z_new_data:expr) => {{
+        let status = $st;
+
+        assert_eq!(status.x_overrun(), $x_overrun);
+        assert_eq!(status.y_overrun(), $y_overrun);
+        assert_eq!(status.z_overrun(), $z_overrun);
+        assert_eq!(status.xyz_overrun(), $xyz_overrun);
+
+        assert_eq!(status.x_new_data(), $x_new_data);
+        assert_eq!(status.y_new_data(), $y_new_data);
+        assert_eq!(status.z_new_data(), $z_new_data);
+        assert_eq!(status.xyz_new_data(), $xyz_new_data);
+    }};
 }
 
 macro_rules! get_st_test {

--- a/tests/temperature_sensor.rs
+++ b/tests/temperature_sensor.rs
@@ -14,7 +14,7 @@ fn can_read_temperature_has_new_data() {
         vec![BF::TDA],
     )]);
 
-    assert!(sensor.temperature_status().unwrap().new_data);
+    assert!(sensor.temperature_status().unwrap().new_data());
     destroy_i2c(sensor);
 }
 
@@ -26,7 +26,7 @@ fn can_read_temperature_has_data_overrun() {
         vec![BF::TOR],
     )]);
 
-    assert!(sensor.temperature_status().unwrap().overrun);
+    assert!(sensor.temperature_status().unwrap().overrun());
     destroy_i2c(sensor);
 }
 
@@ -38,7 +38,7 @@ fn can_read_temperature_has_no_new_data() {
         vec![0x00],
     )]);
 
-    assert!(!sensor.temperature_status().unwrap().new_data);
+    assert!(!sensor.temperature_status().unwrap().new_data());
     destroy_i2c(sensor);
 }
 


### PR DESCRIPTION
- Store returned status directly as `u8` instead of as multiple `bool`s.
- Use `bitflags` for the status flags to get nicer debug output. Also renamed the flags to match the datasheet.