### PR TITLE
Replace `Measurement` and `UnscaledMeasurement` with explicit `Acceleration` and `MagneticField` structs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Support temperature sensor.
 - Support magnetometer offset cancellation.
-- Reduce size of status structs.
-- Simplify API by using explicit types for each measurement.
+- [breaking-change] Reduce size of status structs.
+- [breaking-change] Simplify API by using explicit types for each measurement.
 
 ## [0.2.2] - 2021-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support temperature sensor.
 - Support magnetometer offset cancellation.
 - Reduce size of status structs.
+- Simplify API by using explicit types for each measurement.
 
 ## [0.2.2] - 2021-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support magnetometer offset cancellation.
 - [breaking-change] Reduce size of status structs.
 - [breaking-change] Simplify API by using explicit types for each measurement.
+- Minimum supported Rust version has been upgraded to 1.46.0
 
 ## [0.2.2] - 2021-09-21
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,10 @@ nb = "1"
 bitflags = "1.3"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
 embedded-hal-mock = "0.8"
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+linux-embedded-hal = "0.3"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -13,21 +13,18 @@ This driver allows you to:
 - Connect through I2C or SPI. See: `new_with_i2c()`.
 - Initialize the device. See: `init()`.
 - Accelerometer:
-    - Read accelerometer data. See: `accel_data()`.
-    - Read accelerometer data unscaled. See: `accel_data_unscaled()`.
+    - Read measured acceleration. See: `acceleration()`.
     - Get accelerometer status. See: `accel_status()`.
     - Set accelerometer output data rate. See: `set_accel_odr()`.
     - Set accelerometer mode. See: `set_accel_mode()`.
     - Set accelerometer scale. See: `set_accel_scale()`.
     - Get accelerometer ID. See: `accelerometer_id()`.
     - Get temperature sensor status. See: `temperature_status()`.
-    - Get temperature sensor data. See: `temperature_data()`.
-    - Get temperature sensor data in celsius. See: `temperature_celsius()`.
+    - Read measured temperature. See: `temperature()`.
 - Magnetometer:
     - Get the magnetometer status. See: `mag_status()`.
     - Change into continuous/one-shot mode. See: `into_mag_continuous()`.
-    - Read magnetometer data. See: `mag_data()`.
-    - Read magnetometer data unscaled. See: `mag_data_unscaled()`.
+    - Read measured magnetic field. See: `magnetic_field()`.
     - Set magnetometer output data rate. See: `set_mag_odr()`.
     - Get magnetometer ID. See: `magnetometer_id()`.
     - Enable/disable magnetometer built in offset cancellation. See: `enable_mag_offset_cancellation()`.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ fn main() {
     sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     loop {
         if sensor.accel_status().unwrap().xyz_new_data() {
-            let data = sensor.accel_data().unwrap();
-            println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
+            let data = sensor.acceleration().unwrap();
+            println!("Acceleration: x {} y {} z {}", data.x_mg(), data.y_mg(), data.z_mg());
         }
     }
 }

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -1,7 +1,8 @@
-use linux_embedded_hal::I2cdev;
-use lsm303agr::{AccelOutputDataRate, Lsm303agr};
-
+#[cfg(target_os = "linux")]
 fn main() {
+    use linux_embedded_hal::I2cdev;
+    use lsm303agr::{AccelOutputDataRate, Lsm303agr};
+
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let mut sensor = Lsm303agr::new_with_i2c(dev);
     sensor.init().unwrap();
@@ -18,3 +19,6 @@ fn main() {
         }
     }
 }
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/examples/linux.rs
+++ b/examples/linux.rs
@@ -8,8 +8,13 @@ fn main() {
     sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     loop {
         if sensor.accel_status().unwrap().xyz_new_data() {
-            let data = sensor.accel_data().unwrap();
-            println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
+            let data = sensor.acceleration().unwrap();
+            println!(
+                "Acceleration: x {} y {} z {}",
+                data.x_mg(),
+                data.y_mg(),
+                data.z_mg()
+            );
         }
     }
 }

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -65,9 +65,7 @@ where
     /// Initialize registers
     pub fn init(&mut self) -> Result<(), Error<CommE, PinE>> {
         self.acc_enable_temp()?; // Also enables BDU.
-        self.mag_enable_bdu()?;
-
-        Ok(())
+        self.mag_enable_bdu()
     }
 
     /// Enable block data update for accelerometer.

--- a/src/device_impl.rs
+++ b/src/device_impl.rs
@@ -3,7 +3,7 @@ use crate::{
     mode,
     register_address::{WHO_AM_I_A_VAL, WHO_AM_I_M_VAL},
     Acceleration, BitFlags as BF, Config, Error, Lsm303agr, PhantomData, Register, Status,
-    TemperatureStatus,
+    Temperature, TemperatureStatus,
 };
 
 impl<I2C> Lsm303agr<I2cInterface<I2C>, mode::MagOneShot> {
@@ -64,21 +64,32 @@ where
 {
     /// Initialize registers
     pub fn init(&mut self) -> Result<(), Error<CommE, PinE>> {
-        let temp_cfg_reg = self
-            .temp_cfg_reg_a
-            .with_high(BF::TEMP_EN0)
-            .with_high(BF::TEMP_EN1);
-        self.iface
-            .write_accel_register(Register::TEMP_CFG_REG_A, temp_cfg_reg.bits)?;
-        self.temp_cfg_reg_a = temp_cfg_reg;
         let reg4 = self.ctrl_reg4_a.with_high(BF::ACCEL_BDU);
         self.iface
             .write_accel_register(Register::CTRL_REG4_A, reg4.bits)?;
         self.ctrl_reg4_a = reg4;
+
         let regc = self.cfg_reg_c_m.with_high(BF::MAG_BDU);
         self.iface
             .write_mag_register(Register::CFG_REG_C_M, regc.bits)?;
         self.cfg_reg_c_m = regc;
+
+        Ok(())
+    }
+
+    /// Enable the temperature sensor.
+    #[inline]
+    fn enable_temperature_sensor(&mut self) -> Result<(), Error<CommE, PinE>> {
+        if self.temp_cfg_reg_a.is_high(BF::TEMP_EN) {
+            // Already enabled.
+            return Ok(());
+        }
+
+        let temp_cfg_reg = self.temp_cfg_reg_a.with_high(BF::TEMP_EN);
+        self.iface
+            .write_accel_register(Register::TEMP_CFG_REG_A, temp_cfg_reg.bits)?;
+        self.temp_cfg_reg_a = temp_cfg_reg;
+
         Ok(())
     }
 
@@ -131,24 +142,19 @@ where
         Ok(self.magnetometer_id()? == WHO_AM_I_M_VAL)
     }
 
-    /// Read temperature sensor data
-    pub fn temperature_data(&mut self) -> Result<i16, Error<CommE, PinE>> {
+    /// Get measured temperature.
+    pub fn temperature(&mut self) -> Result<Temperature, Error<CommE, PinE>> {
         let data = self
             .iface
             .read_accel_double_register(Register::OUT_TEMP_L_A)?;
-        Ok(data as i16)
-    }
 
-    /// Read temperature sensor data as celsius
-    pub fn temperature_celsius(&mut self) -> Result<f32, Error<CommE, PinE>> {
-        let data = self.temperature_data()?;
-        let temp_offset = (data as f32) / 256.0;
-        let default_temp = 25.0;
-        Ok(temp_offset + default_temp)
+        Ok(Temperature { raw: data })
     }
 
     /// Temperature sensor status
     pub fn temperature_status(&mut self) -> Result<TemperatureStatus, Error<CommE, PinE>> {
+        self.enable_temperature_sensor()?;
+
         self.iface
             .read_accel_register(Register::STATUS_REG_AUX_A)
             .map(TemperatureStatus::new)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ mod magnetometer;
 mod types;
 pub use crate::types::{
     mode, AccelMode, AccelOutputDataRate, AccelScale, Acceleration, Error, MagOutputDataRate,
-    Measurement, ModeChangeError, Status, TemperatureStatus, UnscaledMeasurement,
+    MagneticField, ModeChangeError, Status, TemperatureStatus,
 };
 mod register_address;
 use crate::register_address::{BitFlags, Register};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ mod magnetometer;
 mod types;
 pub use crate::types::{
     mode, AccelMode, AccelOutputDataRate, AccelScale, Acceleration, Error, MagOutputDataRate,
-    MagneticField, ModeChangeError, Status, TemperatureStatus,
+    MagneticField, ModeChangeError, Status, Temperature, TemperatureStatus,
 };
 mod register_address;
 use crate::register_address::{BitFlags, Register};
@@ -160,7 +160,7 @@ impl Config {
         }
     }
     fn is_high(self, mask: u8) -> bool {
-        (self.bits & mask) != 0
+        (self.bits & mask) == mask
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@
 //!
 //! loop {
 //!     if sensor.accel_status().unwrap().xyz_new_data() {
-//!         let data = sensor.accel_data().unwrap();
-//!         println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
+//!         let data = sensor.acceleration().unwrap();
+//!         println!("Acceleration: x {} y {} z {}", data.x_mg(), data.y_mg(), data.z_mg());
 //!     }
 //! }
 //! ```
@@ -104,8 +104,8 @@
 //!
 //! loop {
 //!     if sensor.accel_status().unwrap().xyz_new_data() {
-//!         let data = sensor.accel_data().unwrap();
-//!         println!("Acceleration: x {} y {} z {}", data.x, data.y, data.z);
+//!         let data = sensor.acceleration().unwrap();
+//!         println!("Acceleration: x {} y {} z {}", data.x_mg(), data.y_mg(), data.z_mg());
 //!     }
 //! }
 //! ```
@@ -122,8 +122,8 @@ mod mag_mode_change;
 mod magnetometer;
 mod types;
 pub use crate::types::{
-    mode, AccelMode, AccelOutputDataRate, AccelScale, Error, MagOutputDataRate, Measurement,
-    ModeChangeError, Status, TemperatureStatus, UnscaledMeasurement,
+    mode, AccelMode, AccelOutputDataRate, AccelScale, Acceleration, Error, MagOutputDataRate,
+    Measurement, ModeChangeError, Status, TemperatureStatus, UnscaledMeasurement,
 };
 mod register_address;
 use crate::register_address::{BitFlags, Register};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,24 +5,21 @@
 //! [`embedded-hal`]: https://github.com/rust-embedded/embedded-hal
 //!
 //! This driver allows you to:
-//! - Connect through I2C or SPI. See: [`new_with_i2c()`](Lsm303agr::new_with_i2c).
+//! - Connect through I2C or SPI. See: [`new_with_i2c()`](Lsm303agr::new_with_i2c) and [`new_with_spi()`](Lsm303agr::new_with_spi) .
 //! - Initialize the device. See: [`init()`](Lsm303agr::init).
 //! - Accelerometer:
-//!     - Read accelerometer data. See: [`accel_data()`](Lsm303agr::accel_data).
-//!     - Read accelerometer data unscaled. See: [`accel_data()`](Lsm303agr::accel_data_unscaled).
+//!     - Read measured acceleration. See: [`acceleration()`](Lsm303agr::acceleration).
 //!     - Get accelerometer status. See: [`accel_status()`](Lsm303agr::accel_status).
 //!     - Set accelerometer output data rate. See: [`set_accel_odr()`](Lsm303agr::set_accel_odr).
 //!     - Set accelerometer mode. See: [`set_accel_mode()`](Lsm303agr::set_accel_mode).
 //!     - Set accelerometer scale. See: [`set_accel_scale()`](Lsm303agr::set_accel_scale).
 //!     - Get accelerometer ID. See: [`accelerometer_id()`](Lsm303agr::accelerometer_id).
 //!     - Get temperature sensor status. See: [`temperature_status()`](Lsm303agr::temperature_status).
-//!     - Get temperature sensor data. See: [`temperature_data()`](Lsm303agr::temperature_data).
-//!     - Get temperature sensor data in celsius. See: [`temperature_celsius()`](Lsm303agr::temperature_celsius).
+//!     - Read measured temperature. See: [`temperature()`](Lsm303agr::temperature).
 //! - Magnetometer:
 //!     - Get the magnetometer status. See: [`mag_status()`](Lsm303agr::mag_status).
 //!     - Change into continuous/one-shot mode. See: [`into_mag_continuous()`](Lsm303agr::into_mag_continuous).
-//!     - Read magnetometer data. See: [`mag_data()`](Lsm303agr::mag_data).
-//!     - Read magnetometer data unscaled. See: [`mag_data()`](Lsm303agr::mag_data_unscaled).
+//!     - Read measured magnetic field. See: [`magnetic_field()`](Lsm303agr::magnetic_field).
 //!     - Set magnetometer output data rate. See: [`set_mag_odr()`](Lsm303agr::set_mag_odr).
 //!     - Get magnetometer ID. See: [`magnetometer_id()`](Lsm303agr::magnetometer_id).
 //!     - Enable/disable magnetometer built in offset cancellation. See: [`enable_mag_offset_cancellation()`](Lsm303agr::enable_mag_offset_cancellation).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,13 +154,15 @@ impl Config {
             bits: self.bits | mask,
         }
     }
+
     fn with_low(self, mask: u8) -> Self {
         Config {
             bits: self.bits & !mask,
         }
     }
+
     fn is_high(self, mask: u8) -> bool {
-        (self.bits & mask) == mask
+        (self.bits & mask) != 0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //! ### Connect through I2C, initialize and take some measurements
 //!
 //! ```no_run
+//! # #[cfg(target_os = "linux")] {
 //! use linux_embedded_hal::I2cdev;
 //! use lsm303agr::{AccelOutputDataRate, Lsm303agr};
 //!
@@ -86,11 +87,13 @@
 //!         println!("Acceleration: x {} y {} z {}", data.x_mg(), data.y_mg(), data.z_mg());
 //!     }
 //! }
+//! # }
 //! ```
 //!
 //! ### Connect through SPI, initialize and take some measurements
 //!
 //! ```no_run
+//! # #[cfg(target_os = "linux")] {
 //! use linux_embedded_hal::{Spidev, Pin};
 //! use lsm303agr::{AccelOutputDataRate, Lsm303agr};
 //!
@@ -108,6 +111,7 @@
 //!         println!("Acceleration: x {} y {} z {}", data.x_mg(), data.y_mg(), data.z_mg());
 //!     }
 //! }
+//! # }
 //! ```
 
 #![deny(unsafe_code, missing_docs)]

--- a/src/register_address.rs
+++ b/src/register_address.rs
@@ -36,4 +36,5 @@ impl BitFlags {
 
     pub const TEMP_EN0: u8 = 1 << 6;
     pub const TEMP_EN1: u8 = 1 << 7;
+    pub const TEMP_EN: u8 = Self::TEMP_EN0 | Self::TEMP_EN1;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -404,3 +404,31 @@ impl TemperatureStatus {
         self.flags.contains(TemperatureStatusFlags::TDA)
     }
 }
+
+/// A temperature measurement.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Temperature {
+    pub(crate) raw: u16,
+}
+
+impl Temperature {
+    const DEFAULT: f32 = 25.0;
+
+    /// Raw temperature.
+    #[inline]
+    pub const fn raw(&self) -> u16 {
+        self.raw
+    }
+
+    /// Unscaled temperature.
+    #[inline]
+    pub const fn unscaled(&self) -> i16 {
+        self.raw as i16
+    }
+
+    /// Temperature in °C.
+    #[inline]
+    pub fn degrees_celsius(&self) -> f32 {
+        (self.unscaled() as f32) / 256.0 + Self::DEFAULT
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -127,26 +127,88 @@ impl Acceleration {
     }
 }
 
-/// Measurement
+/// A magnetic field measurement.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Measurement {
-    /// X-axis data.
-    pub x: i32,
-    /// Y-axis data.
-    pub y: i32,
-    /// Z-axis data.
-    pub z: i32,
+pub struct MagneticField {
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+    pub(crate) z: u16,
 }
 
-/// Unscaled measurement
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct UnscaledMeasurement {
-    /// X-axis data.
-    pub x: i16,
-    /// Y-axis data.
-    pub y: i16,
-    /// Z-axis data.
-    pub z: i16,
+impl MagneticField {
+    const SCALING_FACTOR: i32 = 150;
+
+    /// Raw magnetic field in X-direction.
+    #[inline]
+    pub const fn x_raw(&self) -> u16 {
+        self.x
+    }
+
+    /// Raw magnetic field in Y-direction.
+    #[inline]
+    pub const fn y_raw(&self) -> u16 {
+        self.y
+    }
+
+    /// Raw magnetic field in Z-direction.
+    #[inline]
+    pub const fn z_raw(&self) -> u16 {
+        self.z
+    }
+
+    /// Raw magnetic field in X-, Y- and Z-directions.
+    #[inline]
+    pub const fn xyz_raw(&self) -> (u16, u16, u16) {
+        (self.x, self.y, self.z)
+    }
+
+    /// Unscaled magnetic field in X-direction.
+    #[inline]
+    pub const fn x_unscaled(&self) -> i16 {
+        self.x as i16
+    }
+
+    /// Unscaled magnetic field in Y-direction.
+    #[inline]
+    pub const fn y_unscaled(&self) -> i16 {
+        self.y as i16
+    }
+
+    /// Unscaled magnetic field in Z-direction.
+    #[inline]
+    pub const fn z_unscaled(&self) -> i16 {
+        self.z as i16
+    }
+
+    /// Unscaled magnetic field in X-, Y- and Z-directions.
+    #[inline]
+    pub const fn xyz_unscaled(&self) -> (i16, i16, i16) {
+        (self.x as i16, self.y as i16, self.z as i16)
+    }
+
+    /// Magnetic field in X-direction in nT (nano-Tesla).
+    #[inline]
+    pub const fn x_nt(&self) -> i32 {
+        (self.x_unscaled() as i32) * Self::SCALING_FACTOR
+    }
+
+    /// Magnetic field in Y-direction in nT (nano-Tesla).
+    #[inline]
+    pub const fn y_nt(&self) -> i32 {
+        (self.y_unscaled() as i32) * Self::SCALING_FACTOR
+    }
+
+    /// Magnetic field in Z-direction in nT (nano-Tesla).
+    #[inline]
+    pub const fn z_nt(&self) -> i32 {
+        (self.z_unscaled() as i32) * Self::SCALING_FACTOR
+    }
+
+    /// Magnetic field in X-, Y- and Z-directions in nT (nano-Tesla).
+    #[inline]
+    pub const fn xyz_nt(&self) -> (i32, i32, i32) {
+        (self.x_nt(), self.y_nt(), self.z_nt())
+    }
 }
 
 /// Accelerometer output data rate

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 mod common;
 use crate::common::{
-    default_cs, default_cs_n, destroy_i2c, destroy_spi, new_i2c, new_spi, new_spi_accel,
+    default_cs, destroy_i2c, destroy_spi, new_i2c, new_spi, new_spi_accel,
     new_spi_mag, BitFlags as BF, Register, ACCEL_ADDR, MAG_ADDR,
 };
 use embedded_hal_mock::{
@@ -130,10 +130,6 @@ fn spi_magnetometer_is_detected() {
 #[test]
 fn can_init_i2c() {
     let mut sensor = new_i2c(&[
-        I2cTrans::write(
-            ACCEL_ADDR,
-            vec![Register::TEMP_CFG_REG_A, BF::TEMP_EN0 | BF::TEMP_EN1],
-        ),
         I2cTrans::write(ACCEL_ADDR, vec![Register::CTRL_REG4_A, BF::ACCEL_BDU]),
         I2cTrans::write(MAG_ADDR, vec![Register::CFG_REG_C_M, BF::MAG_BDU]),
     ]);
@@ -145,11 +141,10 @@ fn can_init_i2c() {
 fn can_init_spi() {
     let mut sensor = new_spi(
         &[
-            SpiTrans::write(vec![Register::TEMP_CFG_REG_A, BF::TEMP_EN0 | BF::TEMP_EN1]),
             SpiTrans::write(vec![Register::CTRL_REG4_A, BF::ACCEL_BDU]),
             SpiTrans::write(vec![Register::CFG_REG_C_M, BF::MAG_BDU]),
         ],
-        default_cs_n(2),
+        default_cs(),
         default_cs(),
     );
     sensor.init().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 mod common;
 use crate::common::{
-    default_cs, destroy_i2c, destroy_spi, new_i2c, new_spi, new_spi_accel,
+    default_cs, default_cs_n, destroy_i2c, destroy_spi, new_i2c, new_spi, new_spi_accel,
     new_spi_mag, BitFlags as BF, Register, ACCEL_ADDR, MAG_ADDR,
 };
 use embedded_hal_mock::{
@@ -131,6 +131,10 @@ fn spi_magnetometer_is_detected() {
 fn can_init_i2c() {
     let mut sensor = new_i2c(&[
         I2cTrans::write(ACCEL_ADDR, vec![Register::CTRL_REG4_A, BF::ACCEL_BDU]),
+        I2cTrans::write(
+            ACCEL_ADDR,
+            vec![Register::TEMP_CFG_REG_A, BF::TEMP_EN1 | BF::TEMP_EN0],
+        ),
         I2cTrans::write(MAG_ADDR, vec![Register::CFG_REG_C_M, BF::MAG_BDU]),
     ]);
     sensor.init().unwrap();
@@ -142,9 +146,10 @@ fn can_init_spi() {
     let mut sensor = new_spi(
         &[
             SpiTrans::write(vec![Register::CTRL_REG4_A, BF::ACCEL_BDU]),
+            SpiTrans::write(vec![Register::TEMP_CFG_REG_A, BF::TEMP_EN1 | BF::TEMP_EN0]),
             SpiTrans::write(vec![Register::CFG_REG_C_M, BF::MAG_BDU]),
         ],
-        default_cs(),
+        default_cs_n(2),
         default_cs(),
     );
     sensor.init().unwrap();

--- a/tests/magnetometer.rs
+++ b/tests/magnetometer.rs
@@ -8,7 +8,7 @@ use embedded_hal_mock::{
     pin::{Mock as PinMock, State as PinState, Transaction as PinTrans},
     spi::Transaction as SpiTrans,
 };
-use lsm303agr::{MagOutputDataRate as ODR, Measurement, UnscaledMeasurement};
+use lsm303agr::MagOutputDataRate as ODR;
 
 macro_rules! set_mag_odr {
     ($name:ident, $hz:ident, $value:expr) => {
@@ -43,15 +43,10 @@ fn can_take_one_shot_measurement() {
             vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
         ),
     ]);
-    let data = nb::block!(sensor.mag_data()).unwrap();
-    assert_eq!(
-        data,
-        Measurement {
-            x: 0x2010 * 150,
-            y: 0x4030 * 150,
-            z: 0x6050 * 150,
-        }
-    );
+    let data = nb::block!(sensor.magnetic_field()).unwrap();
+    assert_eq!(data.x_nt(), 0x2010 * 150);
+    assert_eq!(data.y_nt(), 0x4030 * 150);
+    assert_eq!(data.z_nt(), 0x6050 * 150);
     destroy_i2c(sensor);
 }
 
@@ -70,15 +65,10 @@ fn can_take_one_shot_unscaled_measurement() {
             vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
         ),
     ]);
-    let data = nb::block!(sensor.mag_data_unscaled()).unwrap();
-    assert_eq!(
-        data,
-        UnscaledMeasurement {
-            x: 0x2010,
-            y: 0x4030,
-            z: 0x6050,
-        }
-    );
+    let data = nb::block!(sensor.magnetic_field()).unwrap();
+    assert_eq!(data.x_unscaled(), 0x2010);
+    assert_eq!(data.y_unscaled(), 0x4030);
+    assert_eq!(data.z_unscaled(), 0x6050);
     destroy_i2c(sensor);
 }
 
@@ -93,15 +83,10 @@ fn can_take_continuous_measurement() {
         ),
     ]);
     let mut sensor = sensor.into_mag_continuous().ok().unwrap();
-    let data = sensor.mag_data().unwrap();
-    assert_eq!(
-        data,
-        Measurement {
-            x: 0x2010 * 150,
-            y: 0x4030 * 150,
-            z: 0x6050 * 150,
-        }
-    );
+    let data = sensor.magnetic_field().unwrap();
+    assert_eq!(data.x_nt(), 0x2010 * 150);
+    assert_eq!(data.y_nt(), 0x4030 * 150);
+    assert_eq!(data.z_nt(), 0x6050 * 150);
     destroy_i2c(sensor);
 }
 
@@ -116,15 +101,10 @@ fn can_take_continuous_unscaled_measurement() {
         ),
     ]);
     let mut sensor = sensor.into_mag_continuous().ok().unwrap();
-    let data = sensor.mag_data_unscaled().unwrap();
-    assert_eq!(
-        data,
-        UnscaledMeasurement {
-            x: 0x2010,
-            y: 0x4030,
-            z: 0x6050,
-        }
-    );
+    let data = sensor.magnetic_field().unwrap();
+    assert_eq!(data.x_unscaled(), 0x2010);
+    assert_eq!(data.y_unscaled(), 0x4030);
+    assert_eq!(data.z_unscaled(), 0x6050);
     destroy_i2c(sensor);
 }
 
@@ -154,15 +134,10 @@ fn can_take_continuous_measurement_spi() {
         ]),
     );
     let mut sensor = sensor.into_mag_continuous().ok().unwrap();
-    let data = sensor.mag_data().unwrap();
-    assert_eq!(
-        data,
-        Measurement {
-            x: 0x2010 * 150,
-            y: 0x4030 * 150,
-            z: 0x6050 * 150,
-        }
-    );
+    let data = sensor.magnetic_field().unwrap();
+    assert_eq!(data.x_nt(), 0x2010 * 150);
+    assert_eq!(data.y_nt(), 0x4030 * 150);
+    assert_eq!(data.z_nt(), 0x6050 * 150);
     destroy_spi(sensor);
 }
 

--- a/tests/magnetometer.rs
+++ b/tests/magnetometer.rs
@@ -29,7 +29,7 @@ set_mag_odr!(set_mag_odr_hz50, Hz50, 2 << 2);
 set_mag_odr!(set_mag_odr_hz100, Hz100, 3 << 2);
 
 #[test]
-fn can_take_one_shot_measurement() {
+fn can_take_one_shot_measurement_i2c() {
     let mut sensor = new_i2c(&[
         I2cTrans::write_read(MAG_ADDR, vec![Register::STATUS_REG_M], vec![0]),
         I2cTrans::write_read(MAG_ADDR, vec![Register::CFG_REG_A_M], vec![0]), // idle
@@ -44,36 +44,24 @@ fn can_take_one_shot_measurement() {
         ),
     ]);
     let data = nb::block!(sensor.magnetic_field()).unwrap();
-    assert_eq!(data.x_nt(), 0x2010 * 150);
-    assert_eq!(data.y_nt(), 0x4030 * 150);
-    assert_eq!(data.z_nt(), 0x6050 * 150);
-    destroy_i2c(sensor);
-}
 
-#[test]
-fn can_take_one_shot_unscaled_measurement() {
-    let mut sensor = new_i2c(&[
-        I2cTrans::write_read(MAG_ADDR, vec![Register::STATUS_REG_M], vec![0]),
-        I2cTrans::write_read(MAG_ADDR, vec![Register::CFG_REG_A_M], vec![0]), // idle
-        I2cTrans::write(MAG_ADDR, vec![Register::CFG_REG_A_M, 1]),            // start measurement
-        I2cTrans::write_read(MAG_ADDR, vec![Register::STATUS_REG_M], vec![0]),
-        I2cTrans::write_read(MAG_ADDR, vec![Register::CFG_REG_A_M], vec![1]), // continue waiting
-        I2cTrans::write_read(MAG_ADDR, vec![Register::STATUS_REG_M], vec![0xFF]),
-        I2cTrans::write_read(
-            MAG_ADDR,
-            vec![Register::OUTX_L_REG_M | 0x80],
-            vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
-        ),
-    ]);
-    let data = nb::block!(sensor.magnetic_field()).unwrap();
+    assert_eq!(data.x_raw(), 0x2010);
+    assert_eq!(data.y_raw(), 0x4030);
+    assert_eq!(data.z_raw(), 0x6050);
+
     assert_eq!(data.x_unscaled(), 0x2010);
     assert_eq!(data.y_unscaled(), 0x4030);
     assert_eq!(data.z_unscaled(), 0x6050);
+
+    assert_eq!(data.x_nt(), 0x2010 * 150);
+    assert_eq!(data.y_nt(), 0x4030 * 150);
+    assert_eq!(data.z_nt(), 0x6050 * 150);
+
     destroy_i2c(sensor);
 }
 
 #[test]
-fn can_take_continuous_measurement() {
+fn can_take_continuous_measurement_i2c() {
     let sensor = new_i2c(&[
         I2cTrans::write(MAG_ADDR, vec![Register::CFG_REG_A_M, 0]),
         I2cTrans::write_read(
@@ -84,27 +72,19 @@ fn can_take_continuous_measurement() {
     ]);
     let mut sensor = sensor.into_mag_continuous().ok().unwrap();
     let data = sensor.magnetic_field().unwrap();
-    assert_eq!(data.x_nt(), 0x2010 * 150);
-    assert_eq!(data.y_nt(), 0x4030 * 150);
-    assert_eq!(data.z_nt(), 0x6050 * 150);
-    destroy_i2c(sensor);
-}
 
-#[test]
-fn can_take_continuous_unscaled_measurement() {
-    let sensor = new_i2c(&[
-        I2cTrans::write(MAG_ADDR, vec![Register::CFG_REG_A_M, 0]),
-        I2cTrans::write_read(
-            MAG_ADDR,
-            vec![Register::OUTX_L_REG_M | 0x80],
-            vec![0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
-        ),
-    ]);
-    let mut sensor = sensor.into_mag_continuous().ok().unwrap();
-    let data = sensor.magnetic_field().unwrap();
+    assert_eq!(data.x_raw(), 0x2010);
+    assert_eq!(data.y_raw(), 0x4030);
+    assert_eq!(data.z_raw(), 0x6050);
+
     assert_eq!(data.x_unscaled(), 0x2010);
     assert_eq!(data.y_unscaled(), 0x4030);
     assert_eq!(data.z_unscaled(), 0x6050);
+
+    assert_eq!(data.x_nt(), 0x2010 * 150);
+    assert_eq!(data.y_nt(), 0x4030 * 150);
+    assert_eq!(data.z_nt(), 0x6050 * 150);
+
     destroy_i2c(sensor);
 }
 
@@ -135,9 +115,19 @@ fn can_take_continuous_measurement_spi() {
     );
     let mut sensor = sensor.into_mag_continuous().ok().unwrap();
     let data = sensor.magnetic_field().unwrap();
+
+    assert_eq!(data.x_raw(), 0x2010);
+    assert_eq!(data.y_raw(), 0x4030);
+    assert_eq!(data.z_raw(), 0x6050);
+
+    assert_eq!(data.x_unscaled(), 0x2010);
+    assert_eq!(data.y_unscaled(), 0x4030);
+    assert_eq!(data.z_unscaled(), 0x6050);
+
     assert_eq!(data.x_nt(), 0x2010 * 150);
     assert_eq!(data.y_nt(), 0x4030 * 150);
     assert_eq!(data.z_nt(), 0x6050 * 150);
+
     destroy_spi(sensor);
 }
 

--- a/tests/temperature_sensor.rs
+++ b/tests/temperature_sensor.rs
@@ -8,13 +8,11 @@ use lsm303agr::AccelOutputDataRate;
 
 #[test]
 fn can_read_temperature_has_new_data() {
-    let mut sensor = new_i2c(&[
-        I2cTrans::write(
-            ACCEL_ADDR,
-            vec![Register::TEMP_CFG_REG_A, BF::TEMP_EN0 | BF::TEMP_EN1],
-        ),
-        I2cTrans::write_read(ACCEL_ADDR, vec![Register::STATUS_REG_AUX_A], vec![BF::TDA]),
-    ]);
+    let mut sensor = new_i2c(&[I2cTrans::write_read(
+        ACCEL_ADDR,
+        vec![Register::STATUS_REG_AUX_A],
+        vec![BF::TDA],
+    )]);
 
     assert!(sensor.temperature_status().unwrap().new_data());
     destroy_i2c(sensor);
@@ -22,13 +20,11 @@ fn can_read_temperature_has_new_data() {
 
 #[test]
 fn can_read_temperature_has_data_overrun() {
-    let mut sensor = new_i2c(&[
-        I2cTrans::write(
-            ACCEL_ADDR,
-            vec![Register::TEMP_CFG_REG_A, BF::TEMP_EN0 | BF::TEMP_EN1],
-        ),
-        I2cTrans::write_read(ACCEL_ADDR, vec![Register::STATUS_REG_AUX_A], vec![BF::TOR]),
-    ]);
+    let mut sensor = new_i2c(&[I2cTrans::write_read(
+        ACCEL_ADDR,
+        vec![Register::STATUS_REG_AUX_A],
+        vec![BF::TOR],
+    )]);
 
     assert!(sensor.temperature_status().unwrap().overrun());
     destroy_i2c(sensor);
@@ -36,13 +32,11 @@ fn can_read_temperature_has_data_overrun() {
 
 #[test]
 fn can_read_temperature_has_no_new_data() {
-    let mut sensor = new_i2c(&[
-        I2cTrans::write(
-            ACCEL_ADDR,
-            vec![Register::TEMP_CFG_REG_A, BF::TEMP_EN0 | BF::TEMP_EN1],
-        ),
-        I2cTrans::write_read(ACCEL_ADDR, vec![Register::STATUS_REG_AUX_A], vec![0x00]),
-    ]);
+    let mut sensor = new_i2c(&[I2cTrans::write_read(
+        ACCEL_ADDR,
+        vec![Register::STATUS_REG_AUX_A],
+        vec![0x00],
+    )]);
 
     assert!(!sensor.temperature_status().unwrap().new_data());
     destroy_i2c(sensor);

--- a/tests/temperature_sensor.rs
+++ b/tests/temperature_sensor.rs
@@ -43,7 +43,7 @@ fn can_read_temperature_has_no_new_data() {
 }
 
 #[test]
-fn can_read_raw_temperature_data() {
+fn can_read_temperature_i2c() {
     let mut sensor = new_i2c(&[
         I2cTrans::write(
             ACCEL_ADDR,
@@ -52,41 +52,22 @@ fn can_read_raw_temperature_data() {
         I2cTrans::write_read(
             ACCEL_ADDR,
             vec![Register::OUT_TEMP_L_A | 0x80],
-            vec![0x10, 0x20],
+            vec![0xb3, 0xe2],
         ),
     ]);
 
     sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     let data = sensor.temperature().unwrap();
-    assert_eq!(data.unscaled(), 0x2010);
+
+    assert_eq!(data.raw(), 0xe2b3);
+    assert_eq!(data.unscaled(), -7501);
+    assert_eq!((data.degrees_celsius() * 10.0).round() / 10.0, -4.3);
+
     destroy_i2c(sensor);
 }
 
 #[test]
-fn can_read_celsius_temperature_data() {
-    let mut sensor = new_i2c(&[
-        I2cTrans::write(
-            ACCEL_ADDR,
-            vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50],
-        ),
-        I2cTrans::write_read(
-            ACCEL_ADDR,
-            vec![Register::OUT_TEMP_L_A | 0x80],
-            vec![0x10, 0x20],
-        ),
-    ]);
-
-    sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
-    let data = sensor.temperature().unwrap();
-    assert_eq!(
-        data.degrees_celsius().round() as i32,
-        ((0x2010 as f64 / 256.0) + 25.0).round() as i32
-    );
-    destroy_i2c(sensor);
-}
-
-#[test]
-fn can_read_raw_temperature_data_spi() {
+fn can_read_temperature_spi() {
     let mut sensor = new_spi_accel(
         &[
             SpiTrans::write(vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50]),
@@ -100,28 +81,10 @@ fn can_read_raw_temperature_data_spi() {
 
     sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
     let data = sensor.temperature().unwrap();
-    assert_eq!(data.unscaled(), 0x2010);
-    destroy_spi(sensor);
-}
 
-#[test]
-fn can_read_celsius_temperature_data_spi() {
-    let mut sensor = new_spi_accel(
-        &[
-            SpiTrans::write(vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50]),
-            SpiTrans::transfer(
-                vec![Register::OUT_TEMP_L_A | BF::SPI_RW | BF::SPI_MS, 0, 0],
-                vec![0, 0x10, 0x20],
-            ),
-        ],
-        default_cs_n(2),
-    );
+    assert_eq!(data.raw(), 0x2010);
+    assert_eq!(data.unscaled(), 8208);
+    assert_eq!((data.degrees_celsius() * 10.0).round() / 10.0, 57.1);
 
-    sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
-    let data = sensor.temperature().unwrap();
-    assert_eq!(
-        data.degrees_celsius().round() as i32,
-        ((0x2010 as f64 / 256.0) + 25.0).round() as i32
-    );
     destroy_spi(sensor);
 }


### PR DESCRIPTION
Simplify the API by having only one method each for measuring, with the conversion (unscaled/m*g*/nT) being done by the explicit types.

Also included the changes from https://github.com/eldruin/lsm303agr-rs/pull/11.