### PR TITLE
Improve coverage.

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -133,3 +133,23 @@ pub fn new_i2c(
 pub fn destroy_i2c<MODE>(sensor: Lsm303agr<interface::I2cInterface<I2cMock>, MODE>) {
     sensor.destroy().done();
 }
+
+#[macro_export]
+macro_rules! assert_eq_xyz {
+    ($data:expr, $x_unit:ident, $y_unit:ident, $z_unit:ident, $xyz_unit:ident) => {{
+        let (x_raw, y_raw, z_raw) = $data.xyz_raw();
+        assert_eq!($data.x_raw(), x_raw);
+        assert_eq!($data.y_raw(), y_raw);
+        assert_eq!($data.z_raw(), z_raw);
+
+        let (x_unscaled, y_unscaled, z_unscaled) = $data.xyz_unscaled();
+        assert_eq!($data.x_unscaled(), x_unscaled);
+        assert_eq!($data.y_unscaled(), y_unscaled);
+        assert_eq!($data.z_unscaled(), z_unscaled);
+
+        let (x_unit, y_unit, z_unit) = $data.$xyz_unit();
+        assert_eq!($data.$x_unit(), x_unit);
+        assert_eq!($data.$y_unit(), y_unit);
+        assert_eq!($data.$z_unit(), z_unit);
+    }};
+}

--- a/tests/magnetometer.rs
+++ b/tests/magnetometer.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 mod common;
 use crate::common::{
     destroy_i2c, destroy_spi, new_i2c, new_spi_mag, BitFlags as BF, Register, DEFAULT_CFG_REG_A_M,
@@ -28,6 +29,12 @@ set_mag_odr!(set_mag_odr_hz20, Hz20, 1 << 2);
 set_mag_odr!(set_mag_odr_hz50, Hz50, 2 << 2);
 set_mag_odr!(set_mag_odr_hz100, Hz100, 3 << 2);
 
+macro_rules! assert_eq_xyz_nt {
+    ($data:expr) => {{
+        crate::assert_eq_xyz!($data, x_nt, y_nt, z_nt, xyz_nt);
+    }};
+}
+
 #[test]
 fn can_take_one_shot_measurement_i2c() {
     let mut sensor = new_i2c(&[
@@ -44,6 +51,8 @@ fn can_take_one_shot_measurement_i2c() {
         ),
     ]);
     let data = nb::block!(sensor.magnetic_field()).unwrap();
+
+    assert_eq_xyz_nt!(data);
 
     assert_eq!(data.x_raw(), 0x2010);
     assert_eq!(data.y_raw(), 0x4030);
@@ -72,6 +81,8 @@ fn can_take_continuous_measurement_i2c() {
     ]);
     let mut sensor = sensor.into_mag_continuous().ok().unwrap();
     let data = sensor.magnetic_field().unwrap();
+
+    assert_eq_xyz_nt!(data);
 
     assert_eq!(data.x_raw(), 0x2010);
     assert_eq!(data.y_raw(), 0x4030);
@@ -115,6 +126,8 @@ fn can_take_continuous_measurement_spi() {
     );
     let mut sensor = sensor.into_mag_continuous().ok().unwrap();
     let data = sensor.magnetic_field().unwrap();
+
+    assert_eq_xyz_nt!(data);
 
     assert_eq!(data.x_raw(), 0x2010);
     assert_eq!(data.y_raw(), 0x4030);

--- a/tests/read_accel.rs
+++ b/tests/read_accel.rs
@@ -143,6 +143,12 @@ macro_rules! measurement_almost_eq {
     }};
 }
 
+macro_rules! assert_eq_xyz_mg {
+    ($data:expr) => {{
+        crate::assert_eq_xyz!($data, x_mg, y_mg, z_mg, xyz_mg);
+    }};
+}
+
 #[test]
 fn can_get_8_bit_data_i2c() {
     let mut sensor = new_i2c(&[
@@ -171,6 +177,8 @@ fn can_get_8_bit_data_i2c() {
         .set_accel_mode(&mut Delay, AccelMode::LowPower)
         .unwrap();
     let data = sensor.acceleration().unwrap();
+
+    assert_eq_xyz_mg!(data);
 
     assert_eq!(data.x_raw(), 0x2010);
     assert_eq!(data.y_raw(), 0x4030);
@@ -210,6 +218,8 @@ fn can_get_10_bit_data_i2c() {
         .set_accel_odr(&mut Delay, AccelOutputDataRate::Hz50)
         .unwrap();
     let data = sensor.acceleration().unwrap();
+
+    assert_eq_xyz_mg!(data);
 
     assert_eq!(data.x_raw(), 0x2010);
     assert_eq!(data.y_raw(), 0x4030);
@@ -258,6 +268,8 @@ fn can_get_10_bit_data_spi() {
         .unwrap();
     let data = sensor.acceleration().unwrap();
 
+    assert_eq_xyz_mg!(data);
+
     assert_eq!(data.x_raw(), 0x2010);
     assert_eq!(data.y_raw(), 0x4030);
     assert_eq!(data.z_raw(), 0x6050);
@@ -303,6 +315,8 @@ fn can_get_12_bit_data_i2c() {
         .set_accel_mode(&mut Delay, AccelMode::HighResolution)
         .unwrap();
     let data = sensor.acceleration().unwrap();
+
+    assert_eq_xyz_mg!(data);
 
     assert_eq!(data.x_raw(), 0x2010);
     assert_eq!(data.y_raw(), 0x4030);


### PR DESCRIPTION
Cover the `xyz` variants for measurement types.