### PR TITLE
Update to embedded-hal 1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [breaking-change] Update to embedded-hal 1.0.
 
 ## [0.3.0] - 2023-07-17
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ nb = "1.1"
 bitflags = "2.3.3"
 
 [dev-dependencies]
-embedded-hal-mock = "0.10.0"
+embedded-hal-mock = { version = "0.10", default-features = false, features = ["eh1"] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 linux-embedded-hal = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,15 @@ documentation = "https://docs.rs/lsm303agr"
 edition = "2018"
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 nb = "1.1"
 bitflags = "2.3.3"
 
 [dev-dependencies]
-embedded-hal-mock = "0.9"
+embedded-hal-mock = "0.10.0"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-linux-embedded-hal = "0.3"
+linux-embedded-hal = "0.4.0"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,13 +82,12 @@
 //!
 //! ```no_run
 //! # #[cfg(target_os = "linux")] {
-//! use linux_embedded_hal::{Delay, Spidev, Pin};
+//! use linux_embedded_hal::{Delay, SpidevDevice};
 //! use lsm303agr::{AccelMode, AccelOutputDataRate, Lsm303agr};
 //!
-//! let dev = Spidev::open("/dev/spidev0.0").unwrap();
-//! let accel_cs = Pin::new(17);
-//! let mag_cs = Pin::new(27);
-//! let mut sensor = Lsm303agr::new_with_spi(dev, accel_cs, mag_cs);
+//! let accel_dev = SpidevDevice::open("/dev/spidev0.0").unwrap();
+//! let mag_dev = SpidevDevice::open("/dev/spidev0.1").unwrap();
+//! let mut sensor = Lsm303agr::new_with_spi(accel_dev, mag_dev);
 //!
 //! sensor.init().unwrap();
 //! sensor.set_accel_mode_and_odr(&mut Delay, AccelMode::Normal, AccelOutputDataRate::Hz10).unwrap();
@@ -145,6 +144,6 @@ mod private {
     use crate::interface;
     pub trait Sealed {}
 
-    impl<SPI, CSXL, CSMAG> Sealed for interface::SpiInterface<SPI, CSXL, CSMAG> {}
+    impl<SPIXL, SPIMAG> Sealed for interface::SpiInterface<SPIXL, SPIMAG> {}
     impl<I2C> Sealed for interface::I2cInterface<I2C> {}
 }

--- a/src/mag_mode_change.rs
+++ b/src/mag_mode_change.rs
@@ -3,14 +3,14 @@ use crate::{
     mode, Error, Lsm303agr, ModeChangeError, PhantomData,
 };
 
-impl<DI, CommE, PinE> Lsm303agr<DI, mode::MagOneShot>
+impl<DI, CommE> Lsm303agr<DI, mode::MagOneShot>
 where
-    DI: ReadData<Error = Error<CommE, PinE>> + WriteData<Error = Error<CommE, PinE>>,
+    DI: ReadData<Error = Error<CommE>> + WriteData<Error = Error<CommE>>,
 {
     /// Change the magnetometer to continuous measurement mode
     pub fn into_mag_continuous(
         mut self,
-    ) -> Result<Lsm303agr<DI, mode::MagContinuous>, ModeChangeError<CommE, PinE, Self>> {
+    ) -> Result<Lsm303agr<DI, mode::MagContinuous>, ModeChangeError<CommE, Self>> {
         let cfg = self.cfg_reg_a_m.continuous_mode();
         match self.iface.write_mag_register(cfg) {
             Err(error) => Err(ModeChangeError { error, dev: self }),
@@ -32,9 +32,9 @@ where
     }
 }
 
-impl<DI, CommE, PinE> Lsm303agr<DI, mode::MagContinuous>
+impl<DI, CommE> Lsm303agr<DI, mode::MagContinuous>
 where
-    DI: ReadData<Error = Error<CommE, PinE>> + WriteData<Error = Error<CommE, PinE>>,
+    DI: ReadData<Error = Error<CommE>> + WriteData<Error = Error<CommE>>,
 {
     /// Change the magnetometer to one-shot mode
     ///
@@ -42,7 +42,7 @@ where
     /// is started.
     pub fn into_mag_one_shot(
         mut self,
-    ) -> Result<Lsm303agr<DI, mode::MagOneShot>, ModeChangeError<CommE, PinE, Self>> {
+    ) -> Result<Lsm303agr<DI, mode::MagOneShot>, ModeChangeError<CommE, Self>> {
         let cfg = self.cfg_reg_a_m.idle_mode();
         match self.iface.write_mag_register(cfg) {
             Err(error) => Err(ModeChangeError { error, dev: self }),

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,20 +4,24 @@ use crate::register_address::{RegRead, StatusRegAuxA, WhoAmIA, WhoAmIM};
 
 /// All possible errors in this crate
 #[derive(Debug)]
-pub enum Error<CommE, PinE> {
+pub enum Error<CommE> {
     /// I²C / SPI communication error
     Comm(CommE),
-    /// Chip-select pin error (SPI)
-    Pin(PinE),
     /// Invalid input data provided
     InvalidInputData,
 }
 
+impl<CommE> From<CommE> for Error<CommE> {
+    fn from(e: CommE) -> Self {
+        Self::Comm(e)
+    }
+}
+
 /// All possible errors in this crate
 #[derive(Debug)]
-pub struct ModeChangeError<CommE, PinE, DEV> {
+pub struct ModeChangeError<CommE, DEV> {
     /// I²C / SPI communication error
-    pub error: Error<CommE, PinE>,
+    pub error: Error<CommE>,
     /// Original device without mode changed
     pub dev: DEV,
 }

--- a/tests/accel_mode_and_odr.rs
+++ b/tests/accel_mode_and_odr.rs
@@ -2,7 +2,7 @@ mod common;
 use crate::common::{
     destroy_i2c, new_i2c, BitFlags as BF, Register, ACCEL_ADDR, DEFAULT_CTRL_REG1_A,
 };
-use embedded_hal_mock::{delay::MockNoop as Delay, i2c::Transaction as I2cTrans};
+use embedded_hal_mock::eh1::{delay::NoopDelay as Delay, i2c::Transaction as I2cTrans};
 use lsm303agr::{AccelMode as Mode, AccelOutputDataRate as ODR, FifoMode, Interrupt};
 
 macro_rules! low_pwr {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,5 @@
-use embedded_hal_mock::{
+use embedded_hal_mock::eh1::{
     i2c::{Mock as I2cMock, Transaction as I2cTrans},
-    pin::{Mock as PinMock, State as PinState, Transaction as PinTrans},
     spi::{Mock as SpiMock, Transaction as SpiTrans},
 };
 use lsm303agr::{interface, mode, Lsm303agr};
@@ -74,55 +73,37 @@ impl BitFlags {
 }
 
 #[allow(unused)]
-pub fn default_cs() -> PinMock {
-    default_cs_n(1)
-}
-
-#[allow(unused)]
-pub fn default_cs_n(n: usize) -> PinMock {
-    PinMock::new(
-        &[PinTrans::set(PinState::Low), PinTrans::set(PinState::High)]
-            .iter()
-            .cycle()
-            .take(n * 2)
-            .cloned()
-            .collect::<Vec<_>>(),
-    )
-}
-
-#[allow(unused)]
 pub fn new_spi_accel(
-    transactions: &[SpiTrans],
-    accel_cs: PinMock,
-) -> Lsm303agr<interface::SpiInterface<SpiMock, PinMock, PinMock>, mode::MagOneShot> {
-    Lsm303agr::new_with_spi(SpiMock::new(transactions), accel_cs, PinMock::new(&[]))
+    transactions: &[SpiTrans<u8>],
+) -> Lsm303agr<interface::SpiInterface<SpiMock<u8>, SpiMock<u8>>, mode::MagOneShot> {
+    new_spi(transactions, &[])
 }
 
 #[allow(unused)]
 pub fn new_spi_mag(
-    transactions: &[SpiTrans],
-    mag_cs: PinMock,
-) -> Lsm303agr<interface::SpiInterface<SpiMock, PinMock, PinMock>, mode::MagOneShot> {
-    Lsm303agr::new_with_spi(SpiMock::new(transactions), PinMock::new(&[]), mag_cs)
+    transactions: &[SpiTrans<u8>],
+) -> Lsm303agr<interface::SpiInterface<SpiMock<u8>, SpiMock<u8>>, mode::MagOneShot> {
+    new_spi(&[], transactions)
 }
 
 #[allow(unused)]
 pub fn new_spi(
-    transactions: &[SpiTrans],
-    accel_cs: PinMock,
-    mag_cs: PinMock,
-) -> Lsm303agr<interface::SpiInterface<SpiMock, PinMock, PinMock>, mode::MagOneShot> {
-    Lsm303agr::new_with_spi(SpiMock::new(transactions), accel_cs, mag_cs)
+    accel_transactions: &[SpiTrans<u8>],
+    mag_transactions: &[SpiTrans<u8>],
+) -> Lsm303agr<interface::SpiInterface<SpiMock<u8>, SpiMock<u8>>, mode::MagOneShot> {
+    Lsm303agr::new_with_spi(
+        SpiMock::new(accel_transactions),
+        SpiMock::new(mag_transactions),
+    )
 }
 
 #[allow(unused)]
 pub fn destroy_spi<MODE>(
-    sensor: Lsm303agr<interface::SpiInterface<SpiMock, PinMock, PinMock>, MODE>,
+    sensor: Lsm303agr<interface::SpiInterface<SpiMock<u8>, SpiMock<u8>>, MODE>,
 ) {
-    let (mut spi, mut accel_cs, mut mag_cs) = sensor.destroy();
-    spi.done();
-    accel_cs.done();
-    mag_cs.done();
+    let (mut accel_spi, mut mag_spi) = sensor.destroy();
+    accel_spi.done();
+    mag_spi.done();
 }
 
 #[allow(unused)]

--- a/tests/mag_mode_change.rs
+++ b/tests/mag_mode_change.rs
@@ -1,6 +1,6 @@
 mod common;
 use crate::common::{destroy_i2c, new_i2c, Register, MAG_ADDR};
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 
 #[test]
 fn can_change_into_continuous() {

--- a/tests/read_accel.rs
+++ b/tests/read_accel.rs
@@ -1,10 +1,10 @@
 mod common;
 use crate::common::{
-    default_cs_n, destroy_i2c, destroy_spi, new_i2c, new_spi_accel, BitFlags as BF, Register,
-    ACCEL_ADDR, DEFAULT_CTRL_REG1_A, HZ50,
+    destroy_i2c, destroy_spi, new_i2c, new_spi_accel, BitFlags as BF, Register, ACCEL_ADDR,
+    DEFAULT_CTRL_REG1_A, HZ50,
 };
-use embedded_hal_mock::{
-    delay::MockNoop as Delay, i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans,
+use embedded_hal_mock::eh1::{
+    delay::NoopDelay as Delay, i2c::Transaction as I2cTrans, spi::Transaction as SpiTrans,
 };
 use lsm303agr::{AccelMode, AccelOutputDataRate, AccelScale};
 
@@ -240,25 +240,28 @@ fn can_get_10_bit_data_i2c() {
 
 #[test]
 fn can_get_10_bit_data_spi() {
-    let mut sensor = new_spi_accel(
-        &[
-            SpiTrans::write(vec![Register::CTRL_REG4_A, 0]),
-            SpiTrans::write(vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50]),
-            SpiTrans::transfer(
-                vec![
-                    Register::OUT_X_L_A | BF::SPI_RW | BF::SPI_MS,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                ],
-                vec![0, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
-            ),
-        ],
-        default_cs_n(3),
-    );
+    let mut sensor = new_spi_accel(&[
+        SpiTrans::transaction_start(),
+        SpiTrans::write_vec(vec![Register::CTRL_REG4_A, 0]),
+        SpiTrans::transaction_end(),
+        SpiTrans::transaction_start(),
+        SpiTrans::write_vec(vec![Register::CTRL_REG1_A, DEFAULT_CTRL_REG1_A | HZ50]),
+        SpiTrans::transaction_end(),
+        SpiTrans::transaction_start(),
+        SpiTrans::transfer_in_place(
+            vec![
+                Register::OUT_X_L_A | BF::SPI_RW | BF::SPI_MS,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            vec![0, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60],
+        ),
+        SpiTrans::transaction_end(),
+    ]);
     sensor
         .set_accel_mode_and_odr(&mut Delay, AccelMode::Normal, AccelOutputDataRate::Hz50)
         .unwrap();

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -1,6 +1,6 @@
 mod common;
 use crate::common::{destroy_i2c, new_i2c, BitFlags as BF, Register, ACCEL_ADDR, MAG_ADDR};
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 
 macro_rules! status_eq {
     ($st:expr, $xyz_overrun:expr, $x_overrun:expr, $y_overrun:expr, $z_overrun:expr,


### PR DESCRIPTION
Most notably, embedded-hal now distinguishes between SPI buses and devices. an SpiDevice implementation manages the CS pin itself, so we don't need to do so manually anymore.